### PR TITLE
Changed `constraint-error` into `nabl-constraint`. Added warnings for separators on non-list placeholders.

### DIFF
--- a/org.strategoxt.imp.editors.template/trans/check.str
+++ b/org.strategoxt.imp.editors.template/trans/check.str
@@ -33,3 +33,4 @@ rules
       <fetch(?Separator(_))> lst;
       msg := "You specify a separator, but this isn't a list.";
       <task-create-warning(|ctx, msg)> t
+


### PR DESCRIPTION
Changed: `constraint-error` into `nabl-constraint` as the old way doesn't work anymore.
Added: Warning for templates such as:

```
Params.Params = <<ID; separator=",">>
```

Changing `ID` into `ID*` or `ID+` removes the warning.
