### PR TITLE
handle optional layout in template conversion

### DIFF
--- a/org.strategoxt.imp.editors.template/trans/generation/to-template.str
+++ b/org.strategoxt.imp.editors.template/trans/generation/to-template.str
@@ -79,7 +79,7 @@ rules // Convert regular productions to desugared syntax templates
     	//; debug(! "b")
     
     symbol-to-elem:
-    	<Cf(Layout()) + Lex(Layout())> -> Layout(" ")
+    	<Cf(Opt(Layout())) + Cf(Layout()) + Lex(Layout())> -> Layout(" ")
     	
     symbol-to-elem:
     	Lex(s) -> <symbol-to-elem> s


### PR DESCRIPTION
This is a partial fix for http://yellowgrass.org/issue/SDF/73. 

To fix this completely, `symbol-to-elem` needs to handle all symbols. Currently, it cannot handle `-CF` or `-LEX` variants of EBNF operators applied to `LAYOUT`.

I am also not sure if `LAYOUT?-CF` should yield the same as `LAYOUT-CF` in the conversion, as proposed by this fix.
