### PR TITLE
Update DynSem signatures and extend signature generator

### DIFF
--- a/org.strategoxt.imp.editors.template/lib/ds/pp/Common-pp.str
+++ b/org.strategoxt.imp.editors.template/lib/ds/pp/Common-pp.str
@@ -3,6 +3,7 @@ module ds/pp/Common-pp
 imports
   libstratego-gpp
   runtime/tmpl/pp
+  libstratego-sglr
   ds/signatures/Common-sig
 
 
@@ -23,6 +24,9 @@ strategies
   is-NONE =
     fail
 
+  ds-prettyprint-NONE :
+    amb([h|hs]) -> <ds-prettyprint-NONE> h
+
 
 strategies
   ds-prettyprint-INFER =
@@ -42,6 +46,15 @@ strategies
 
   ds-prettyprint-example =
     ds-prettyprint-LID
+
+  ds-prettyprint-INFER :
+    amb([h|hs]) -> <ds-prettyprint-INFER> h
+
+  ds-prettyprint-ID :
+    amb([h|hs]) -> <ds-prettyprint-ID> h
+
+  ds-prettyprint-LID :
+    amb([h|hs]) -> <ds-prettyprint-LID> h
 
 
 strategies
@@ -92,3 +105,27 @@ strategies
 
   ds-prettyprint-example =
     ds-prettyprint-EOF
+
+  ds-prettyprint-JID :
+    amb([h|hs]) -> <ds-prettyprint-JID> h
+
+  ds-prettyprint-INT :
+    amb([h|hs]) -> <ds-prettyprint-INT> h
+
+  ds-prettyprint-REAL :
+    amb([h|hs]) -> <ds-prettyprint-REAL> h
+
+  ds-prettyprint-STRING :
+    amb([h|hs]) -> <ds-prettyprint-STRING> h
+
+  ds-prettyprint-StringChar :
+    amb([h|hs]) -> <ds-prettyprint-StringChar> h
+
+  ds-prettyprint-BackSlashChar :
+    amb([h|hs]) -> <ds-prettyprint-BackSlashChar> h
+
+  ds-prettyprint-CommentChar :
+    amb([h|hs]) -> <ds-prettyprint-CommentChar> h
+
+  ds-prettyprint-EOF :
+    amb([h|hs]) -> <ds-prettyprint-EOF> h

--- a/org.strategoxt.imp.editors.template/lib/ds/pp/Module-pp.str
+++ b/org.strategoxt.imp.editors.template/lib/ds/pp/Module-pp.str
@@ -3,6 +3,7 @@ module ds/pp/Module-pp
 imports
   libstratego-gpp
   runtime/tmpl/pp
+  libstratego-sglr
   ds/signatures/Module-sig
 
 
@@ -78,6 +79,15 @@ strategies
   is-ImportModule =
     fail
 
+  ds-prettyprint-Module :
+    amb([h|hs]) -> <ds-prettyprint-Module> h
+
+  ds-prettyprint-ModuleSection :
+    amb([h|hs]) -> <ds-prettyprint-ModuleSection> h
+
+  ds-prettyprint-ImportModule :
+    amb([h|hs]) -> <ds-prettyprint-ImportModule> h
+
 
 strategies
   ds-prettyprint-ModuleID =
@@ -91,3 +101,9 @@ strategies
 
   ds-prettyprint-example =
     ds-prettyprint-ModuleIDPart
+
+  ds-prettyprint-ModuleID :
+    amb([h|hs]) -> <ds-prettyprint-ModuleID> h
+
+  ds-prettyprint-ModuleIDPart :
+    amb([h|hs]) -> <ds-prettyprint-ModuleIDPart> h

--- a/org.strategoxt.imp.editors.template/lib/ds/pp/Signatures-pp.str
+++ b/org.strategoxt.imp.editors.template/lib/ds/pp/Signatures-pp.str
@@ -3,6 +3,7 @@ module ds/pp/Signatures-pp
 imports
   libstratego-gpp
   runtime/tmpl/pp
+  libstratego-sglr
   ds/signatures/Signatures-sig
 
 
@@ -35,6 +36,9 @@ strategies
   is-ModuleSection =
     fail
 
+  ds-prettyprint-ModuleSection :
+    amb([h|hs]) -> <ds-prettyprint-ModuleSection> h
+
 
 strategies
   ds-prettyprint-example =
@@ -66,28 +70,116 @@ strategies
   is-SortDecl =
     ?SortDecl(_)
 
-  ds-prettyprint-SortDecl :
-    InjDecl(t1__, t2__) -> [ H(
-                               [SOpt(HS(), "0")]
-                             , [t1__', S(" -> "), t2__']
-                             )
-                           ]
-    with t1__' := <pp-one-Z(ds-prettyprint-ID)> t1__
-    with t2__' := <pp-one-Z(ds-prettyprint-ID)> t2__
-
-  is-SortDecl =
-    ?InjDecl(_, _)
-
   is-SignatureSection =
     fail
 
   is-SortDecl =
     fail
 
+  ds-prettyprint-SignatureSection :
+    amb([h|hs]) -> <ds-prettyprint-SignatureSection> h
+
+  ds-prettyprint-SortDecl :
+    amb([h|hs]) -> <ds-prettyprint-SortDecl> h
+
 
 strategies
   ds-prettyprint-example =
     ds-prettyprint-SignatureSection
+
+  ds-prettyprint-example =
+    ds-prettyprint-VariableScheme
+
+  ds-prettyprint-SignatureSection :
+    VariableSchemes(t1__) -> [ H(
+                                 [SOpt(HS(), "0")]
+                               , [S("variables")]
+                               )
+                             , t1__'
+                             ]
+    with t1__' := <pp-indent(|"2")> [<pp-V-list(ds-prettyprint-VariableScheme)> t1__]
+
+  is-SignatureSection =
+    ?VariableSchemes(_)
+
+  ds-prettyprint-VariableScheme :
+    VariableScheme(t1__, t2__) -> [ H(
+                                      [SOpt(HS(), "0")]
+                                    , [t1__', S(" : "), t2__']
+                                    )
+                                  ]
+    with t1__' := <pp-one-Z(ds-prettyprint-ID)> t1__
+    with t2__' := <pp-one-Z(ds-prettyprint-Type)> t2__
+
+  is-VariableScheme =
+    ?VariableScheme(_, _)
+
+  is-SignatureSection =
+    fail
+
+  is-VariableScheme =
+    fail
+
+  ds-prettyprint-SignatureSection :
+    amb([h|hs]) -> <ds-prettyprint-SignatureSection> h
+
+  ds-prettyprint-VariableScheme :
+    amb([h|hs]) -> <ds-prettyprint-VariableScheme> h
+
+
+strategies
+  ds-prettyprint-example =
+    ds-prettyprint-SignatureSection
+
+  ds-prettyprint-example =
+    ds-prettyprint-AliasDecl
+
+  ds-prettyprint-SignatureSection :
+    Aliases(t1__) -> [ H(
+                         [SOpt(HS(), "0")]
+                       , [S("aliases")]
+                       )
+                     , t1__'
+                     ]
+    with t1__' := <pp-indent(|"2")> [<pp-V-list(ds-prettyprint-AliasDecl)> t1__]
+
+  is-SignatureSection =
+    ?Aliases(_)
+
+  ds-prettyprint-AliasDecl :
+    AliasDecl(t1__, t2__) -> [ H(
+                                 [SOpt(HS(), "0")]
+                               , [t1__', S(" : "), t2__']
+                               )
+                             ]
+    with t1__' := <pp-one-Z(ds-prettyprint-ID)> t1__
+    with t2__' := <pp-one-Z(ds-prettyprint-Type)> t2__
+
+  is-AliasDecl =
+    ?AliasDecl(_, _)
+
+  is-SignatureSection =
+    fail
+
+  is-AliasDecl =
+    fail
+
+  ds-prettyprint-SignatureSection :
+    amb([h|hs]) -> <ds-prettyprint-SignatureSection> h
+
+  ds-prettyprint-AliasDecl :
+    amb([h|hs]) -> <ds-prettyprint-AliasDecl> h
+
+
+strategies
+  ds-prettyprint-example =
+    ds-prettyprint-SignatureSection
+
+  ds-prettyprint-example =
+    ds-prettyprint-ConsAnnos
+
+  ds-prettyprint-example =
+    ds-prettyprint-ConsAnno
 
   ds-prettyprint-example =
     ds-prettyprint-ConsDecl
@@ -111,22 +203,95 @@ strategies
     ?Constructors(_)
 
   ds-prettyprint-ConsDecl :
-    ConsDecl(t1__, t2__, t3__) -> [ H(
-                                      [SOpt(HS(), "0")]
-                                    , [ t1__'
-                                      , S(" : ")
-                                      , t2__'
-                                      , S(" -> ")
-                                      , t3__'
-                                      ]
-                                    )
-                                  ]
+    NullaryConsDecl(t1__, t2__, t3__) -> [ H(
+                                             [SOpt(HS(), "0")]
+                                           , [ t1__'
+                                             , S(" : ")
+                                             , t2__'
+                                             , S(" ")
+                                             , t3__'
+                                             ]
+                                           )
+                                         ]
+    with t1__' := <pp-one-Z(ds-prettyprint-ID)> t1__
+    with t2__' := <pp-one-Z(ds-prettyprint-Type)> t2__
+    with t3__' := <pp-one-Z(ds-prettyprint-ConsAnnos)> t3__
+
+  is-ConsDecl =
+    ?NullaryConsDecl(_, _, _)
+
+  ds-prettyprint-ConsDecl :
+    ConsDecl(t1__, t2__, t3__, t4__) -> [ H(
+                                            [SOpt(HS(), "0")]
+                                          , [ t1__'
+                                            , S(" : ")
+                                            , t2__'
+                                            , S(" -> ")
+                                            , t3__'
+                                            , S(" ")
+                                            , t4__'
+                                            ]
+                                          )
+                                        ]
+    with t1__' := <pp-one-Z(ds-prettyprint-ID)> t1__
+    with t2__' := <pp-H-list(ds-prettyprint-Type|" * ")> t2__
+    with t3__' := <pp-one-Z(ds-prettyprint-Type)> t3__
+    with t4__' := <pp-one-Z(ds-prettyprint-ConsAnnos)> t4__
+
+  is-ConsDecl =
+    ?ConsDecl(_, _, _, _)
+
+  ds-prettyprint-ConsAnnos :
+    NoAnnos() -> [ H(
+                     []
+                   , [S("")]
+                   )
+                 ]
+
+  is-ConsAnnos =
+    ?NoAnnos()
+
+  ds-prettyprint-ConsAnnos :
+    Annos(t1__) -> [ H(
+                       [SOpt(HS(), "0")]
+                     , [ S("{")
+                       , t1__'
+                       , S("}")
+                       ]
+                     )
+                   ]
+    with t1__' := <pp-H-list(ds-prettyprint-ConsAnno|",")> t1__
+
+  is-ConsAnnos =
+    ?Annos(_)
+
+  ds-prettyprint-ConsAnno :
+    ImplicitAnno() -> [ H(
+                          [SOpt(HS(), "0")]
+                        , [S("implicit")]
+                        )
+                      ]
+
+  is-ConsAnno =
+    ?ImplicitAnno()
+
+  ds-prettyprint-ConsDecl :
+    FunDecl(t1__, t2__, t3__) -> [ H(
+                                     [SOpt(HS(), "0")]
+                                   , [ t1__'
+                                     , S(" : ")
+                                     , t2__'
+                                     , S(" --> ")
+                                     , t3__'
+                                     ]
+                                   )
+                                 ]
     with t1__' := <pp-one-Z(ds-prettyprint-ID)> t1__
     with t2__' := <pp-H-list(ds-prettyprint-Type|" * ")> t2__
     with t3__' := <pp-one-Z(ds-prettyprint-Type)> t3__
 
   is-ConsDecl =
-    ?ConsDecl(_, _, _)
+    ?FunDecl(_, _, _)
 
   ds-prettyprint-Type :
     SimpleSort(t1__) -> [ H(
@@ -182,6 +347,12 @@ strategies
   is-SignatureSection =
     fail
 
+  is-ConsAnnos =
+    fail
+
+  is-ConsAnno =
+    fail
+
   is-ConsDecl =
     fail
 
@@ -191,92 +362,23 @@ strategies
   is-MapType =
     fail
 
-
-strategies
-  ds-prettyprint-example =
-    ds-prettyprint-SignatureSection
-
-  ds-prettyprint-example =
-    ds-prettyprint-SemanticCompDecl
-
   ds-prettyprint-SignatureSection :
-    SemanticComponents(t1__) -> [ H(
-                                    [SOpt(HS(), "0")]
-                                  , [S("semantic-components")]
-                                  )
-                                , t1__'
-                                ]
-    with t1__' := <pp-indent(|"2")> [<pp-V-list(ds-prettyprint-SemanticCompDecl)> t1__]
+    amb([h|hs]) -> <ds-prettyprint-SignatureSection> h
 
-  is-SignatureSection =
-    ?SemanticComponents(_)
+  ds-prettyprint-ConsAnnos :
+    amb([h|hs]) -> <ds-prettyprint-ConsAnnos> h
 
-  ds-prettyprint-SemanticCompDecl :
-    SemanticComponent(t1__, t2__) -> [ H(
-                                         [SOpt(HS(), "0")]
-                                       , [t1__', S(" -> "), t2__']
-                                       )
-                                     ]
-    with t1__' := <pp-one-Z(ds-prettyprint-ID)> t1__
-    with t2__' := <pp-one-Z(ds-prettyprint-MapType)> t2__
+  ds-prettyprint-ConsAnno :
+    amb([h|hs]) -> <ds-prettyprint-ConsAnno> h
 
-  is-SemanticCompDecl =
-    ?SemanticComponent(_, _)
+  ds-prettyprint-ConsDecl :
+    amb([h|hs]) -> <ds-prettyprint-ConsDecl> h
 
-  is-SignatureSection =
-    fail
+  ds-prettyprint-Type :
+    amb([h|hs]) -> <ds-prettyprint-Type> h
 
-  is-SemanticCompDecl =
-    fail
-
-
-strategies
-  ds-prettyprint-example =
-    ds-prettyprint-SignatureSection
-
-  ds-prettyprint-example =
-    ds-prettyprint-InternalSortDecl
-
-  ds-prettyprint-SignatureSection :
-    InternalSorts(t1__) -> [ H(
-                               [SOpt(HS(), "0")]
-                             , [S("internal-sorts")]
-                             )
-                           , t1__'
-                           ]
-    with t1__' := <pp-indent(|"2")> [<pp-V-list(ds-prettyprint-InternalSortDecl)> t1__]
-
-  is-SignatureSection =
-    ?InternalSorts(_)
-
-  ds-prettyprint-InternalSortDecl :
-    InternalSortDecl(t1__) -> [ H(
-                                  [SOpt(HS(), "0")]
-                                , [t1__']
-                                )
-                              ]
-    with t1__' := <pp-one-Z(ds-prettyprint-ID)> t1__
-
-  is-InternalSortDecl =
-    ?InternalSortDecl(_)
-
-  ds-prettyprint-InternalSortDecl :
-    InternalInjDecl(t1__, t2__) -> [ H(
-                                       [SOpt(HS(), "0")]
-                                     , [t1__', S(" -> "), t2__']
-                                     )
-                                   ]
-    with t1__' := <pp-one-Z(ds-prettyprint-ID)> t1__
-    with t2__' := <pp-one-Z(ds-prettyprint-ID)> t2__
-
-  is-InternalSortDecl =
-    ?InternalInjDecl(_, _)
-
-  is-SignatureSection =
-    fail
-
-  is-InternalSortDecl =
-    fail
+  ds-prettyprint-MapType :
+    amb([h|hs]) -> <ds-prettyprint-MapType> h
 
 
 strategies
@@ -295,7 +397,7 @@ strategies
   ds-prettyprint-SignatureSection :
     NativeDataTypes(t1__) -> [ H(
                                  [SOpt(HS(), "0")]
-                               , [S("native-datatypes")]
+                               , [S("native datatypes")]
                                )
                              , t1__'
                              ]
@@ -396,6 +498,18 @@ strategies
   is-NativeFunctionDecl =
     fail
 
+  ds-prettyprint-SignatureSection :
+    amb([h|hs]) -> <ds-prettyprint-SignatureSection> h
+
+  ds-prettyprint-JSNIPPET :
+    amb([h|hs]) -> <ds-prettyprint-JSNIPPET> h
+
+  ds-prettyprint-NativeTypeDecl :
+    amb([h|hs]) -> <ds-prettyprint-NativeTypeDecl> h
+
+  ds-prettyprint-NativeFunctionDecl :
+    amb([h|hs]) -> <ds-prettyprint-NativeFunctionDecl> h
+
 
 strategies
   ds-prettyprint-example =
@@ -407,7 +521,7 @@ strategies
   ds-prettyprint-SignatureSection :
     NativeOperators(t1__) -> [ H(
                                  [SOpt(HS(), "0")]
-                               , [S("native-operators")]
+                               , [S("native operators")]
                                )
                              , t1__'
                              ]
@@ -434,55 +548,29 @@ strategies
   is-NativeOpDecl =
     ?NativeOpDecl(_, _, _)
 
+  ds-prettyprint-NativeOpDecl :
+    NullaryNativeOpDecl(t1__, t2__) -> [ H(
+                                           [SOpt(HS(), "0")]
+                                         , [t1__', S(" : "), t2__']
+                                         )
+                                       ]
+    with t1__' := <pp-one-Z(ds-prettyprint-ID)> t1__
+    with t2__' := <pp-one-Z(ds-prettyprint-Type)> t2__
+
+  is-NativeOpDecl =
+    ?NullaryNativeOpDecl(_, _)
+
   is-SignatureSection =
     fail
 
   is-NativeOpDecl =
     fail
 
-
-strategies
-  ds-prettyprint-example =
-    ds-prettyprint-SignatureSection
-
-  ds-prettyprint-example =
-    ds-prettyprint-InternalConsDecl
-
   ds-prettyprint-SignatureSection :
-    InternalConstructors(t1__) -> [ H(
-                                      [SOpt(HS(), "0")]
-                                    , [S("internal-constructors")]
-                                    )
-                                  , t1__'
-                                  ]
-    with t1__' := <pp-indent(|"2")> [<pp-V-list(ds-prettyprint-InternalConsDecl)> t1__]
+    amb([h|hs]) -> <ds-prettyprint-SignatureSection> h
 
-  is-SignatureSection =
-    ?InternalConstructors(_)
-
-  ds-prettyprint-InternalConsDecl :
-    InternalConsDecl(t1__, t2__, t3__) -> [ H(
-                                              [SOpt(HS(), "0")]
-                                            , [ t1__'
-                                              , S(" : ")
-                                              , t2__'
-                                              , S(" -> ")
-                                              , t3__'
-                                              ]
-                                            )
-                                          ]
-    with t1__' := <pp-one-Z(ds-prettyprint-ID)> t1__
-    with t2__' := <pp-H-list(ds-prettyprint-Type|" * ")> t2__
-    with t3__' := <pp-one-Z(ds-prettyprint-Type)> t3__
-
-  is-InternalConsDecl =
-    ?InternalConsDecl(_, _, _)
-
-  is-SignatureSection =
-    fail
-
-  is-InternalConsDecl =
-    fail
+  ds-prettyprint-NativeOpDecl :
+    amb([h|hs]) -> <ds-prettyprint-NativeOpDecl> h
 
 
 strategies
@@ -495,7 +583,7 @@ strategies
   ds-prettyprint-SignatureSection :
     NativeConstructors(t1__) -> [ H(
                                     [SOpt(HS(), "0")]
-                                  , [S("native-constructors")]
+                                  , [S("native constructors")]
                                   )
                                 , t1__'
                                 ]
@@ -522,11 +610,29 @@ strategies
   is-NativeConsDecl =
     ?NativeConsDecl(_, _, _)
 
+  ds-prettyprint-NativeConsDecl :
+    NullaryNativeConsDecl(t1__, t2__) -> [ H(
+                                             [SOpt(HS(), "0")]
+                                           , [t1__', S(" : "), t2__']
+                                           )
+                                         ]
+    with t1__' := <pp-one-Z(ds-prettyprint-ID)> t1__
+    with t2__' := <pp-one-Z(ds-prettyprint-Type)> t2__
+
+  is-NativeConsDecl =
+    ?NullaryNativeConsDecl(_, _)
+
   is-SignatureSection =
     fail
 
   is-NativeConsDecl =
     fail
+
+  ds-prettyprint-SignatureSection :
+    amb([h|hs]) -> <ds-prettyprint-SignatureSection> h
+
+  ds-prettyprint-NativeConsDecl :
+    amb([h|hs]) -> <ds-prettyprint-NativeConsDecl> h
 
 
 strategies
@@ -538,9 +644,6 @@ strategies
 
   ds-prettyprint-example =
     ds-prettyprint-ArrowDeclaration
-
-  ds-prettyprint-example =
-    ds-prettyprint-ArrowTemplateDeclaration
 
   ds-prettyprint-SignatureSection :
     ArrowDeclarations(t1__) -> [ H(
@@ -562,15 +665,6 @@ strategies
             ]
     where not(is-DeclaredArrow)
     where t1__' := <pp-one-Z(ds-prettyprint-ArrowDeclaration)> t1__
-
-  ds-prettyprint-DeclaredArrow :
-    t1__ -> [ H(
-                [SOpt(HS(), "0")]
-              , [t1__']
-              )
-            ]
-    where not(is-DeclaredArrow)
-    where t1__' := <pp-one-Z(ds-prettyprint-ArrowTemplateDeclaration)> t1__
 
   ds-prettyprint-ArrowDeclaration :
     ArrowDecl(t1__, t2__, t3__) -> [ H(
@@ -602,34 +696,6 @@ strategies
   is-ArrowDeclaration =
     ?DefaultArrowDecl(_, _)
 
-  ds-prettyprint-ArrowTemplateDeclaration :
-    ArrowTemplDecl(t1__, t2__, t3__, t4__, t5__, t6__) -> [ H(
-                                                              [SOpt(HS(), "0")]
-                                                            , [ S("forall ")
-                                                              , t1__'
-                                                              , S(", ")
-                                                              , t2__'
-                                                              , S(" -")
-                                                              , t3__'
-                                                              , S("(")
-                                                              , t4__'
-                                                              , S(" -> ")
-                                                              , t5__'
-                                                              , S(")-> ")
-                                                              , t6__'
-                                                              ]
-                                                            )
-                                                          ]
-    with t1__' := <pp-H-list(ds-prettyprint-ID|" ")> t1__
-    with t2__' := <pp-one-Z(ds-prettyprint-Type)> t2__
-    with t3__' := <pp-one-Z(ds-prettyprint-ID)> t3__
-    with t4__' := <pp-one-Z(ds-prettyprint-ID)> t4__
-    with t5__' := <pp-one-Z(ds-prettyprint-ID)> t5__
-    with t6__' := <pp-one-Z(ds-prettyprint-Type)> t6__
-
-  is-ArrowTemplateDeclaration =
-    ?ArrowTemplDecl(_, _, _, _, _, _)
-
   is-SignatureSection =
     fail
 
@@ -639,5 +705,11 @@ strategies
   is-ArrowDeclaration =
     fail
 
-  is-ArrowTemplateDeclaration =
-    fail
+  ds-prettyprint-SignatureSection :
+    amb([h|hs]) -> <ds-prettyprint-SignatureSection> h
+
+  ds-prettyprint-DeclaredArrow :
+    amb([h|hs]) -> <ds-prettyprint-DeclaredArrow> h
+
+  ds-prettyprint-ArrowDeclaration :
+    amb([h|hs]) -> <ds-prettyprint-ArrowDeclaration> h

--- a/org.strategoxt.imp.editors.template/lib/ds/pp/ds-pp.str
+++ b/org.strategoxt.imp.editors.template/lib/ds/pp/ds-pp.str
@@ -3,6 +3,7 @@ module ds/pp/ds-pp
 imports
   libstratego-gpp
   runtime/tmpl/pp
+  libstratego-sglr
   ds/signatures/ds-sig
 
 
@@ -93,7 +94,7 @@ strategies
   ds-prettyprint-Rule :
     Axiom(t1__) -> [ H(
                        [SOpt(HS(), "0")]
-                     , [t1__']
+                     , [t1__', S(".")]
                      )
                    ]
     with t1__' := <pp-one-Z(ds-prettyprint-Formula)> t1__
@@ -115,7 +116,7 @@ strategies
                                 , [t3__']
                                 )
                               ]
-    with t1__' := <pp-V-list(ds-prettyprint-Premise|"0", ",")> t1__
+    with t1__' := <pp-V-list(ds-prettyprint-Premise|"0", ";")> t1__
     with t2__' := <pp-one-Z(ds-prettyprint-INFER)> t2__
     with t3__' := <pp-one-Z(ds-prettyprint-Relation)> t3__
 
@@ -134,7 +135,8 @@ strategies
                          , t2__'
                          ]
     with t1__' := <pp-one-Z(ds-prettyprint-Relation)> t1__
-    with t2__' := <pp-indent(|"2")> [ <pp-V-list(ds-prettyprint-Premise|"0", ",")> t2__
+    with t2__' := <pp-indent(|"2")> [ <pp-V-list(ds-prettyprint-Premise|"0", ";")> t2__
+                                    , S(".")
                                     ]
 
   is-Rule =
@@ -169,7 +171,7 @@ strategies
                           , t1__'
                           , t2__'
                           ]
-    with t1__' := <pp-indent(|"4")> [ <pp-V-list(ds-prettyprint-Premise|"0", ",")> t1__
+    with t1__' := <pp-indent(|"4")> [ <pp-V-list(ds-prettyprint-Premise|"0", ";")> t1__
                                     ]
     with t2__' := <pp-indent(|"2")> [S("}")]
 
@@ -224,6 +226,18 @@ strategies
 
   is-Premise =
     fail
+
+  ds-prettyprint-ModuleSection :
+    amb([h|hs]) -> <ds-prettyprint-ModuleSection> h
+
+  ds-prettyprint-Rule :
+    amb([h|hs]) -> <ds-prettyprint-Rule> h
+
+  ds-prettyprint-PremisesBlock :
+    amb([h|hs]) -> <ds-prettyprint-PremisesBlock> h
+
+  ds-prettyprint-Premise :
+    amb([h|hs]) -> <ds-prettyprint-Premise> h
 
 
 strategies
@@ -379,7 +393,7 @@ strategies
                      , [t1__', S(" |- ")]
                      )
                    ]
-    with t1__' := <pp-H-list(ds-prettyprint-LabelComp|" ")> t1__
+    with t1__' := <pp-H-list(ds-prettyprint-LabelComp|", ")> t1__
 
   is-Reads =
     ?Reads(_)
@@ -402,7 +416,7 @@ strategies
                             )
                           ]
     with t1__' := <pp-one-Z(ds-prettyprint-Term)> t1__
-    with t2__' := <pp-H-list(ds-prettyprint-LabelComp|" ")> t2__
+    with t2__' := <pp-H-list(ds-prettyprint-LabelComp|", ")> t2__
 
   is-Source =
     ?Source(_, _)
@@ -421,15 +435,11 @@ strategies
   ds-prettyprint-Target :
     Target(t1__, t2__) -> [ H(
                               [SOpt(HS(), "0")]
-                            , [ t1__'
-                              , S(" :: ")
-                              , t2__'
-                              , S(".")
-                              ]
+                            , [t1__', S(" :: "), t2__']
                             )
                           ]
     with t1__' := <pp-one-Z(ds-prettyprint-Term)> t1__
-    with t2__' := <pp-H-list(ds-prettyprint-LabelComp|" ")> t2__
+    with t2__' := <pp-H-list(ds-prettyprint-LabelComp|", ")> t2__
 
   is-Target =
     ?Target(_, _)
@@ -459,28 +469,11 @@ strategies
     ?NamedDynamic(_)
 
   ds-prettyprint-Rel :
-    NamedDynamicParametric(t1__, t2__) -> [ H(
-                                              [SOpt(HS(), "0")]
-                                            , [ S("-")
-                                              , t1__'
-                                              , S("(")
-                                              , t2__'
-                                              , S(")->")
-                                              ]
-                                            )
-                                          ]
-    with t1__' := <pp-one-Z(ds-prettyprint-ID)> t1__
-    with t2__' := <pp-one-Z(ds-prettyprint-ID)> t2__
-
-  is-Rel =
-    ?NamedDynamicParametric(_, _)
-
-  ds-prettyprint-Rel :
     DynamicEmitted(t1__) -> [ H(
                                 [SOpt(HS(), "0")]
                               , [ S("-")
                                 , t1__'
-                                , S("->")
+                                , S("-->")
                                 ]
                               )
                             ]
@@ -506,26 +499,6 @@ strategies
   is-Rel =
     ?NamedDynamicEmitted(_, _)
 
-  ds-prettyprint-Rel :
-    NamedDynamicEmittedParametric(t1__, t2__, t3__) -> [ H(
-                                                           [SOpt(HS(), "0")]
-                                                         , [ S("-")
-                                                           , t1__'
-                                                           , S("-")
-                                                           , t2__'
-                                                           , S("(")
-                                                           , t3__'
-                                                           , S(")->")
-                                                           ]
-                                                         )
-                                                       ]
-    with t1__' := <pp-H-list(ds-prettyprint-LabelComp|", ")> t1__
-    with t2__' := <pp-one-Z(ds-prettyprint-ID)> t2__
-    with t3__' := <pp-one-Z(ds-prettyprint-ID)> t3__
-
-  is-Rel =
-    ?NamedDynamicEmittedParametric(_, _, _)
-
   ds-prettyprint-LabelComp :
     LabelComp(t1__, t2__) -> [ H(
                                  [SOpt(HS(), "0")]
@@ -537,6 +510,17 @@ strategies
 
   is-LabelComp =
     ?LabelComp(_, _)
+
+  ds-prettyprint-LabelComp :
+    VarLabelComp(t1__) -> [ H(
+                              [SOpt(HS(), "0")]
+                            , [t1__']
+                            )
+                          ]
+    with t1__' := <pp-one-Z(ds-prettyprint-Var)> t1__
+
+  is-LabelComp =
+    ?VarLabelComp(_)
 
   is-Relation =
     fail
@@ -559,6 +543,38 @@ strategies
   is-LabelComp =
     fail
 
+  ds-prettyprint-Relation :
+    amb([h|hs]) -> <ds-prettyprint-Relation> h
+
+  ds-prettyprint-Formula :
+    amb([h|hs]) -> <ds-prettyprint-Formula> h
+
+  ds-prettyprint-Reads :
+    amb([h|hs]) -> <ds-prettyprint-Reads> h
+
+  ds-prettyprint-Source :
+    amb([h|hs]) -> <ds-prettyprint-Source> h
+
+  ds-prettyprint-Target :
+    amb([h|hs]) -> <ds-prettyprint-Target> h
+
+  ds-prettyprint-Rel :
+    amb([h|hs]) -> <ds-prettyprint-Rel> h
+
+  ds-prettyprint-LabelComp :
+    amb([h|hs]) -> <ds-prettyprint-LabelComp> h
+
+
+strategies
+  ds-prettyprint-TermCon =
+    ![S(<is-string>)]
+
+  ds-prettyprint-example =
+    ds-prettyprint-TermCon
+
+  ds-prettyprint-TermCon :
+    amb([h|hs]) -> <ds-prettyprint-TermCon> h
+
 
 strategies
   ds-prettyprint-example =
@@ -566,6 +582,9 @@ strategies
 
   ds-prettyprint-example =
     ds-prettyprint-Cast
+
+  ds-prettyprint-example =
+    ds-prettyprint-List
 
   ds-prettyprint-example =
     ds-prettyprint-Entry
@@ -599,7 +618,7 @@ strategies
                           , [t1__', S(" : "), t2__']
                           )
                         ]
-    with t1__' := <pp-one-Z(ds-prettyprint-Var)> t1__
+    with t1__' := <pp-one-Z(ds-prettyprint-Term)> t1__
     with t2__' := <pp-one-Z(ds-prettyprint-Type)> t2__
 
   is-Cast =
@@ -679,13 +698,13 @@ strategies
                            ]
                          )
                        ]
-    with t1__' := <pp-one-Z(ds-prettyprint-ID)> t1__
+    with t1__' := <pp-one-Z(ds-prettyprint-TermCon)> t1__
     with t2__' := <pp-H-list(ds-prettyprint-Term|", ")> t2__
 
   is-Term =
     ?Con(_, _)
 
-  ds-prettyprint-Term :
+  ds-prettyprint-List :
     List(t1__) -> [ H(
                       [SOpt(HS(), "0")]
                     , [ S("[ ")
@@ -696,10 +715,10 @@ strategies
                   ]
     with t1__' := <pp-H-list(ds-prettyprint-Term|", ")> t1__
 
-  is-Term =
+  is-List =
     ?List(_)
 
-  ds-prettyprint-Term :
+  ds-prettyprint-List :
     ListTail(t1__, t2__) -> [ H(
                                 [SOpt(HS(), "0")]
                               , [ S("[ ")
@@ -713,8 +732,17 @@ strategies
     with t1__' := <pp-H-list(ds-prettyprint-Term|", ")> t1__
     with t2__' := <pp-one-Z(ds-prettyprint-Term)> t2__
 
-  is-Term =
+  is-List =
     ?ListTail(_, _)
+
+  ds-prettyprint-Term :
+    t1__ -> [ H(
+                [SOpt(HS(), "0")]
+              , [t1__']
+              )
+            ]
+    where not(is-Term)
+    where t1__' := <pp-one-Z(ds-prettyprint-List)> t1__
 
   ds-prettyprint-Term :
     Fresh() -> [ H(
@@ -860,8 +888,26 @@ strategies
   is-Cast =
     fail
 
+  is-List =
+    fail
+
   is-Entry =
     fail
 
   is-Term =
     fail
+
+  ds-prettyprint-Var :
+    amb([h|hs]) -> <ds-prettyprint-Var> h
+
+  ds-prettyprint-Cast :
+    amb([h|hs]) -> <ds-prettyprint-Cast> h
+
+  ds-prettyprint-List :
+    amb([h|hs]) -> <ds-prettyprint-List> h
+
+  ds-prettyprint-Entry :
+    amb([h|hs]) -> <ds-prettyprint-Entry> h
+
+  ds-prettyprint-Term :
+    amb([h|hs]) -> <ds-prettyprint-Term> h

--- a/org.strategoxt.imp.editors.template/lib/ds/signatures/Signatures-sig.str
+++ b/org.strategoxt.imp.editors.template/lib/ds/signatures/Signatures-sig.str
@@ -12,24 +12,27 @@ signature
   constructors
     Sorts    : List(SortDecl) -> SignatureSection
     SortDecl : ID -> SortDecl
-    InjDecl  : ID * ID -> SortDecl
 
   constructors
-    Constructors : List(ConsDecl) -> SignatureSection
-    ConsDecl     : ID * List(Type) * Type -> ConsDecl
-    SimpleSort   : ID -> Type
-    ListSort     : Type -> Type
-                 : MapType -> Type
-    MapSort      : Type * Type -> MapType
+    VariableSchemes : List(VariableScheme) -> SignatureSection
+    VariableScheme  : ID * Type -> VariableScheme
 
   constructors
-    SemanticComponents : List(SemanticCompDecl) -> SignatureSection
-    SemanticComponent  : ID * MapType -> SemanticCompDecl
+    Aliases   : List(AliasDecl) -> SignatureSection
+    AliasDecl : ID * Type -> AliasDecl
 
   constructors
-    InternalSorts    : List(InternalSortDecl) -> SignatureSection
-    InternalSortDecl : ID -> InternalSortDecl
-    InternalInjDecl  : ID * ID -> InternalSortDecl
+    Constructors    : List(ConsDecl) -> SignatureSection
+    NullaryConsDecl : ID * Type * ConsAnnos -> ConsDecl
+    ConsDecl        : ID * List(Type) * Type * ConsAnnos -> ConsDecl
+    NoAnnos         : ConsAnnos
+    Annos           : List(ConsAnno) -> ConsAnnos
+    ImplicitAnno    : ConsAnno
+    FunDecl         : ID * List(Type) * Type -> ConsDecl
+    SimpleSort      : ID -> Type
+    ListSort        : Type -> Type
+                    : MapType -> Type
+    MapSort         : Type * Type -> MapType
 
   constructors
     NativeDataTypes         : List(NativeTypeDecl) -> SignatureSection
@@ -40,21 +43,17 @@ signature
     NativeNoArgFunctionDecl : ID * Type -> NativeFunctionDecl
 
   constructors
-    NativeOperators : List(NativeOpDecl) -> SignatureSection
-    NativeOpDecl    : ID * List(Type) * Type -> NativeOpDecl
+    NativeOperators     : List(NativeOpDecl) -> SignatureSection
+    NativeOpDecl        : ID * List(Type) * Type -> NativeOpDecl
+    NullaryNativeOpDecl : ID * Type -> NativeOpDecl
 
   constructors
-    InternalConstructors : List(InternalConsDecl) -> SignatureSection
-    InternalConsDecl     : ID * List(Type) * Type -> InternalConsDecl
-
-  constructors
-    NativeConstructors : List(NativeConsDecl) -> SignatureSection
-    NativeConsDecl     : ID * List(Type) * Type -> NativeConsDecl
+    NativeConstructors    : List(NativeConsDecl) -> SignatureSection
+    NativeConsDecl        : ID * List(Type) * Type -> NativeConsDecl
+    NullaryNativeConsDecl : ID * Type -> NativeConsDecl
 
   constructors
     ArrowDeclarations : List(DeclaredArrow) -> SignatureSection
                       : ArrowDeclaration -> DeclaredArrow
-                      : ArrowTemplateDeclaration -> DeclaredArrow
     ArrowDecl         : Type * ID * Type -> ArrowDeclaration
     DefaultArrowDecl  : Type * Type -> ArrowDeclaration
-    ArrowTemplDecl    : List(ID) * Type * ID * ID * ID * Type -> ArrowTemplateDeclaration

--- a/org.strategoxt.imp.editors.template/lib/ds/signatures/ds-sig.str
+++ b/org.strategoxt.imp.editors.template/lib/ds/signatures/ds-sig.str
@@ -21,42 +21,45 @@ signature
     TryOr        : PremisesBlock * PremisesBlock -> Premise
 
   constructors
-    Match                         : Term * Term -> Formula
-    NMatch                        : Term * Term -> Formula
-    TermEq                        : Term * Term -> Formula
-    TermNeq                       : Term * Term -> Formula
-    TypeCheck                     : Var * Type -> Formula
-    TypeCast                      : Var * Type -> Formula
-                                  : Relation -> Formula
-    Relation                      : Reads * Source * Rel * Target -> Relation
-    IsValue                       : Term -> Formula
-    NoReads                       : Reads
-    Reads                         : List(LabelComp) -> Reads
-    Source                        : Term -> Source
-    Source                        : Term * List(LabelComp) -> Source
-    Target                        : Term -> Target
-    Target                        : Term * List(LabelComp) -> Target
-    Dynamic                       : Rel
-    NamedDynamic                  : ID -> Rel
-    NamedDynamicParametric        : ID * ID -> Rel
-    DynamicEmitted                : List(LabelComp) -> Rel
-    NamedDynamicEmitted           : List(LabelComp) * ID -> Rel
-    NamedDynamicEmittedParametric : List(LabelComp) * ID * ID -> Rel
-    LabelComp                     : Type * Term -> LabelComp
+    Match               : Term * Term -> Formula
+    NMatch              : Term * Term -> Formula
+    TermEq              : Term * Term -> Formula
+    TermNeq             : Term * Term -> Formula
+    TypeCheck           : Var * Type -> Formula
+    TypeCast            : Var * Type -> Formula
+                        : Relation -> Formula
+    Relation            : Reads * Source * Rel * Target -> Relation
+    IsValue             : Term -> Formula
+    NoReads             : Reads
+    Reads               : List(LabelComp) -> Reads
+    Source              : Term -> Source
+    Source              : Term * List(LabelComp) -> Source
+    Target              : Term -> Target
+    Target              : Term * List(LabelComp) -> Target
+    Dynamic             : Rel
+    NamedDynamic        : ID -> Rel
+    DynamicEmitted      : List(LabelComp) -> Rel
+    NamedDynamicEmitted : List(LabelComp) * ID -> Rel
+    LabelComp           : Type * Term -> LabelComp
+    VarLabelComp        : Var -> LabelComp
+
+  constructors
+     : String -> TermCon
 
   constructors
     VarRef      : ID -> Var
                 : Var -> Term
-    Cast        : Var * Type -> Cast
+    Cast        : Term * Type -> Cast
                 : Cast -> Term
     As          : Var * Term -> Term
     Wld         : Term
     String      : STRING -> Term
     Int         : INT -> Term
     Real        : REAL -> Term
-    Con         : ID * List(Term) -> Term
-    List        : List(Term) -> Term
-    ListTail    : List(Term) * Term -> Term
+    Con         : TermCon * List(Term) -> Term
+    List        : List(Term) -> List
+    ListTail    : List(Term) * Term -> List
+                : List -> Term
     Fresh       : Term
     True        : Term
     False       : Term

--- a/org.strategoxt.imp.editors.template/trans/generation/to-dynsem-sig.str
+++ b/org.strategoxt.imp.editors.template/trans/generation/to-dynsem-sig.str
@@ -35,6 +35,14 @@ rules
 	sort-to-ds-sig-sort = !SortDecl(<id>)
 	
 	section-to-ds-sig:
+	  SDFSection(LexicalSyntax(p*)) -> Constructors(sig*)
+	  where
+	    sig* := <filter(get-sort-from-prod); nub; map(lexsort-to-ds-implicitcon); not(?[])> p* 
+	
+	lexsort-to-ds-implicitcon:
+    s -> ConsDecl($[__String2[s]__], [SimpleSort("String")], SimpleSort(s), Annos([ImplicitAnno()]))
+	
+	section-to-ds-sig:
   	SDFSection(ContextFreeSyntax(p*)) -> Constructors(sig*)
   		where
   		sig* := <filter(cfg-to-ds-sig <+ template-to-ds-sig); not(?[])> p*

--- a/org.strategoxt.imp.editors.template/trans/generation/to-dynsem-sig.str
+++ b/org.strategoxt.imp.editors.template/trans/generation/to-dynsem-sig.str
@@ -14,23 +14,24 @@ imports
   lib/ds/pp/-
   
   generation/to-str
-  
+  generation/to-sig
   
 rules 
 	
 	module-to-ds-sig:
-		Module(Unparameterized(m), i*, s*) -> Module(m',  [is*, Signatures([Sorts(sorts*), 
-          signatures*])])
+		Module(Unparameterized(m), i*, s*) -> Module(m',  [is*, Signatures([Sorts(sorts*), signatures*])])
 		with
-			m'  := <conc-strings> ("src-gen/", "ds-signatures/", m, "-sig")
-		;   is* := <map(to-str-import(|"-sig", "ds-signatures"))> i*
-		;   sorts* :=  <collect-all(collect-sorts)
-             			; nub
-             			; map(sort-to-ds-sig-sort)> s*
-        ;   signatures* := <filter(section-to-ds-sig)> s*
+		  m'  := <conc-strings> ("src-gen/", "ds-signatures/", m, "-sig");
+		  is* := <map(to-str-import(|"-sig", "ds-signatures"))> i*;
+		  sorts* :=  <collect-all(collect-sorts); nub; map(sort-to-ds-sig-sort)> s*;
+		  signatures* := <filter(section-to-ds-sig)> s*
             
             
-    collect-sorts = ?TemplateProduction(SortDef(<id>),_,_) <+ ?TemplateProductionWithCons(SortCons(SortDef(<id>), _), _, _) <+ ?SdfProduction(SortDef(<id>),_,_) <+ ?SdfProductionWithCons(SortCons(SortDef(<id>), _), _, _)
+  collect-sorts =
+    ?TemplateProduction(SortDef(<id>),_,_)
+    <+ ?TemplateProductionWithCons(SortCons(SortDef(<id>), _), _, _)
+    <+ ?SdfProduction(SortDef(<id>),_,_)
+    <+ ?SdfProductionWithCons(SortCons(SortDef(<id>), _), _, _)
     	    	        	 
 	sort-to-ds-sig-sort = !SortDecl(<id>)
 	
@@ -44,7 +45,7 @@ rules
 	
 	section-to-ds-sig:
   	SDFSection(ContextFreeSyntax(p*)) -> Constructors(sig*)
-  		where
+		where
   		sig* := <filter(cfg-to-ds-sig <+ template-to-ds-sig); not(?[])> p*
 	
 	section-to-ds-sig:
@@ -52,28 +53,27 @@ rules
   	where
   		sig* := <filter(cfg-to-ds-sig); not(?[])> p*		
   		
-  	section-to-ds-sig:
-    TemplateSection(t*) -> Constructors(sig*)
-    with
-      sig* := <filter(template-to-ds-sig); not(?[])> t*	
-  			
+	section-to-ds-sig:
+	  TemplateSection(t*) -> Constructors(sig*)
+	  with
+	    sig* := <filter(template-to-ds-sig); not(?[])> t*	
 			
 	cfg-to-ds-sig:
     SdfProductionWithCons(SortCons(SortDef(s),c), _, Attrs(a*)) -> <cons-to-ds-decl> c
     where
     	<not(fetch-elem(?Reject() + ?Bracket()))> a*
    
-     cfg-to-ds-sig:
+  cfg-to-ds-sig:
     SdfProductionWithCons(SortCons(Cf(SortDef(s)),c), _, Attrs(a*)) -> <cons-to-ds-decl> c
     where
     	<not(fetch-elem(?Reject() + ?Bracket()))> a*	
      	
-    cfg-to-ds-sig:
+  cfg-to-ds-sig:
     SdfProductionWithCons(SortCons(Lex(SortDef(s)),c), _, Attrs(a*)) -> <cons-to-ds-decl> c
     where
     	<not(fetch-elem(?Reject() + ?Bracket()))> a* 
    
-    template-to-ds-sig:
+  template-to-ds-sig:
     TemplateProductionWithCons(SortCons(SortDef(s), c), _, Attrs(a*)) -> <cons-to-ds-decl> c
     where
       <not(fetch-elem(?Reject() + ?Bracket()))> a*  
@@ -91,11 +91,11 @@ rules
         cons-decl := NullaryConsDecl(c, sort, NoAnnos())
       end
     
-    get-sort-name:     
+  get-sort-name:     
     ConstType(SortNoArgs(t)) -> SimpleSort(t)
     
-    get-sort-name:
+  get-sort-name:
     ConstType(Sort("List",[SortNoArgs(s)])) -> ListSort(SimpleSort(s))
     
-    check-fun-type: FunType([], t) -> t
+  check-fun-type: FunType([], t) -> t
     	    

--- a/org.strategoxt.imp.editors.template/trans/generation/to-dynsem-sig.str
+++ b/org.strategoxt.imp.editors.template/trans/generation/to-dynsem-sig.str
@@ -72,7 +72,7 @@ rules
     	
         
     cons-to-ds-decl:
-    Constructor(c) -> ConsDecl(c, rhs*, sort)
+    Constructor(c) -> ConsDecl(c, rhs*, sort, NoAnnos())
     with
       	FunType(rhs-type*, ConstType(SortNoArgs(sort-type))) := <get-type> c;
       	sort := SimpleSort(sort-type);

--- a/org.strategoxt.imp.editors.template/trans/generation/to-dynsem-sig.str
+++ b/org.strategoxt.imp.editors.template/trans/generation/to-dynsem-sig.str
@@ -78,13 +78,18 @@ rules
     where
       <not(fetch-elem(?Reject() + ?Bracket()))> a*  
     	
-        
-    cons-to-ds-decl:
-    Constructor(c) -> ConsDecl(c, rhs*, sort, NoAnnos())
+  cons-to-ds-decl:
+    Constructor(c) -> cons-decl
     with
-      	FunType(rhs-type*, ConstType(SortNoArgs(sort-type))) := <get-type> c;
-      	sort := SimpleSort(sort-type);
-        rhs* := <map(get-sort-name)> rhs-type*
+    	FunType(rhs-type*, ConstType(SortNoArgs(sort-type))) := <get-type> c;
+    	sort := SimpleSort(sort-type);
+      rhs* := <map(get-sort-name)> rhs-type*;
+      if <not(?[])> rhs*
+      then
+        cons-decl := ConsDecl(c, rhs*, sort, NoAnnos())
+      else
+        cons-decl := NullaryConsDecl(c, sort, NoAnnos())
+      end
     
     get-sort-name:     
     ConstType(SortNoArgs(t)) -> SimpleSort(t)

--- a/org.strategoxt.imp.editors.template/trans/generation/to-dynsem-sig.str
+++ b/org.strategoxt.imp.editors.template/trans/generation/to-dynsem-sig.str
@@ -56,8 +56,13 @@ rules
 	section-to-ds-sig:
 	  TemplateSection(t*) -> Constructors(sig*)
 	  with
-	    sig* := <filter(template-to-ds-sig); not(?[])> t*	
-			
+	    sig* := <filter(template-to-ds-sig); not(?[])> t*
+
+  cfg-to-ds-sig:			
+    SdfProduction(SortDef(s1), Rhs([Sort(s2)]), Attrs(a*)) -> <inj-to-ds-decl> (s1, s2)
+    where
+      <not(fetch-elem(?Reject()))> a*
+
 	cfg-to-ds-sig:
     SdfProductionWithCons(SortCons(SortDef(s),c), _, Attrs(a*)) -> <cons-to-ds-decl> c
     where
@@ -72,12 +77,15 @@ rules
     SdfProductionWithCons(SortCons(Lex(SortDef(s)),c), _, Attrs(a*)) -> <cons-to-ds-decl> c
     where
     	<not(fetch-elem(?Reject() + ?Bracket()))> a* 
-   
+  
   template-to-ds-sig:
     TemplateProductionWithCons(SortCons(SortDef(s), c), _, Attrs(a*)) -> <cons-to-ds-decl> c
     where
       <not(fetch-elem(?Reject() + ?Bracket()))> a*  
-    	
+  
+  inj-to-ds-decl:
+    (s1, s2) -> ConsDecl($[__[s2]2[s1]__], [SimpleSort(s2)], SimpleSort(s1), Annos([ImplicitAnno()]))
+  
   cons-to-ds-decl:
     Constructor(c) -> cons-decl
     with

--- a/org.strategoxt.imp.editors.template/trans/generation/to-dynsem-sig.str
+++ b/org.strategoxt.imp.editors.template/trans/generation/to-dynsem-sig.str
@@ -28,7 +28,7 @@ rules
             
             
   collect-sorts =
-    ?TemplateProduction(SortDef(<id>),_,_)
+    ?TemplateProduction(SortDef(s),_,Attrs(<not(fetch-elem(?Reject()))>)); !s
     <+ ?TemplateProductionWithCons(SortCons(SortDef(<id>), _), _, _)
     <+ ?SdfProduction(SortDef(<id>),_,_)
     <+ ?SdfProductionWithCons(SortCons(SortDef(<id>), _), _, _)


### PR DESCRIPTION
Extend the DynSem signature generator with the following:

1. generate correct syntax for nullary constructors
2. try to avoid duplicate sort declarations
3. generate implicit constructors from lexical declarations
4. generate implicit constructors from injections

Also updates the signature and pretty-printer to the latest available for DynSem.