### PR TITLE
Generate DynSem signature on-save

### DIFF
--- a/org.strategoxt.imp.editors.template/trans/editor/builders.str
+++ b/org.strategoxt.imp.editors.template/trans/editor/builders.str
@@ -320,9 +320,13 @@ imports
     	esv-ast              :=  <module-to-esv; pp-esv-to-string <+ !""; debug(!"ESV files could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> ast';
     	<write-string-to-file> (esv-filename, esv-ast) 
     where
-    	sig-ast              := <module-to-sig; pp-stratego-string <+ !""; debug(!"Signature files could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> ast';
-        sig-filename         := <create-src-gen(|project-path, "signatures", "-sig.str")> mn;
-    	<write-string-to-file> (sig-filename, sig-ast)  
+      sig-ast              := <module-to-sig; pp-stratego-string <+ !""; debug(!"Signature files could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> ast';
+      sig-filename         := <create-src-gen(|project-path, "signatures", "-sig.str")> mn;
+      <write-string-to-file> (sig-filename, sig-ast)
+    where
+      ds-sig-ast           := <module-to-ds-sig; pp-ds-to-string  <+ !""; debug(!"The ds signature file could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> ast';
+      ds-sig-filename      := <create-src-gen(|project-path, "ds-signatures", "-sig.ds")> mn;
+      <write-string-to-file> (ds-sig-filename, ds-sig-ast)
     where
     	chars                := <collect-one(?Tokenize(<id; explode-string; un-double-quote-chars>)) <+ !['(', ')']> sections;
   		newline              := <collect-one(?Newlines(<id>)) <+ !None()> sections;

--- a/org.strategoxt.imp.editors.template/trans/generation/to-dynsem-sig.str
+++ b/org.strategoxt.imp.editors.template/trans/generation/to-dynsem-sig.str
@@ -23,7 +23,7 @@ rules
 		with
 		  m'  := <conc-strings> ("src-gen/", "ds-signatures/", m, "-sig");
 		  is* := <map(to-str-import(|"-sig", "ds-signatures"))> i*;
-		  sorts* :=  <collect-all(collect-sorts); nub; map(sort-to-ds-sig-sort)> s*;
+		  sorts* := <collect-all(collect-sorts); nub; map(sort-to-ds-sig-sort)> s*;
 		  signatures* := <filter(section-to-ds-sig)> s*
             
             
@@ -33,7 +33,7 @@ rules
     <+ ?SdfProduction(SortDef(<id>),_,_)
     <+ ?SdfProductionWithCons(SortCons(SortDef(<id>), _), _, _)
     	    	        	 
-	sort-to-ds-sig-sort = !SortDecl(<id>)
+	sort-to-ds-sig-sort = !SortDecl(<ds-escape-sortname>)
 	
 	section-to-ds-sig:
 	  SDFSection(LexicalSyntax(p*)) -> Constructors(sig*)
@@ -41,8 +41,30 @@ rules
 	    sig* := <filter(get-sort-from-prod); nub; map(lexsort-to-ds-implicitcon); not(?[])> p* 
 	
 	lexsort-to-ds-implicitcon:
-    s -> ConsDecl($[__String2[s]__], [SimpleSort("String")], SimpleSort(s), Annos([ImplicitAnno()]))
+    s -> ConsDecl($[__String2[s]__], [SimpleSort("String")], SimpleSort(<ds-escape-sortname> s), Annos([ImplicitAnno()]))
 	
+	
+	ds-reserved-consnames = !["List", "Map"]
+	ds-reserved-sortnames = !["List", "Map", "Int", "Long", "Float", "Real", "Bool"]
+  
+  ds-escape-consname:
+    name -> name''
+    where
+    	name' := <strip-annos> name
+    where
+      name'' := <ds-reserved-consnames; fetch-elem(?name'; !$[[name']_])>
+      <+
+      name'' := name'
+
+  ds-escape-sortname:
+    name -> name''
+    where
+      name' := <strip-annos> name
+    where
+    	name'' := <fetch-elem(?name'; !$[[name']_])> <ds-reserved-sortnames>
+    	<+
+    	name'' := name'
+
 	section-to-ds-sig:
   	SDFSection(ContextFreeSyntax(p*)) -> Constructors(sig*)
 		where
@@ -84,26 +106,31 @@ rules
       <not(fetch-elem(?Reject() + ?Bracket()))> a*  
   
   inj-to-ds-decl:
-    (s1, s2) -> ConsDecl($[__[s2]2[s1]__], [SimpleSort(s2)], SimpleSort(s1), Annos([ImplicitAnno()]))
+    (s1, s2) -> ConsDecl($[__[s2]2[s1]__], [SimpleSort(s2')], SimpleSort(s1'), Annos([ImplicitAnno()]))
+    where
+      s2' := <ds-escape-sortname> s2;
+      s1' := <ds-escape-sortname> s1
   
   cons-to-ds-decl:
     Constructor(c) -> cons-decl
     with
     	FunType(rhs-type*, ConstType(SortNoArgs(sort-type))) := <get-type> c;
-    	sort := SimpleSort(sort-type);
+    	sort := SimpleSort(<ds-escape-sortname> sort-type);
       rhs* := <map(get-sort-name)> rhs-type*;
+      c' := <ds-escape-consname> c;
+      sort' := <ds-escape-sortname> sort;
       if <not(?[])> rhs*
       then
-        cons-decl := ConsDecl(c, rhs*, sort, NoAnnos())
+        cons-decl := ConsDecl(c', rhs*, sort', NoAnnos())
       else
-        cons-decl := NullaryConsDecl(c, sort, NoAnnos())
+        cons-decl := NullaryConsDecl(c', sort', NoAnnos())
       end
     
   get-sort-name:     
-    ConstType(SortNoArgs(t)) -> SimpleSort(t)
+    ConstType(SortNoArgs(t)) -> SimpleSort(<ds-escape-sortname> t)
     
   get-sort-name:
-    ConstType(Sort("List",[SortNoArgs(s)])) -> ListSort(SimpleSort(s))
+    ConstType(Sort("List",[SortNoArgs(s)])) -> ListSort(SimpleSort(<ds-escape-sortname> s))
     
   check-fun-type: FunType([], t) -> t
     	    


### PR DESCRIPTION
This PR hooks the DynSem signature generator into the `generate-all` strategy. This means that DynSem signatures are generated during the build for each language.