### PR TITLE
Fix: NPE in importer bug

### DIFF
--- a/sdf2table.core/src/main/java/org/metaborg/sdf2table/core/CollisionSet.java
+++ b/sdf2table.core/src/main/java/org/metaborg/sdf2table/core/CollisionSet.java
@@ -57,6 +57,8 @@ public class CollisionSet<Value> implements Set<Value>{
 	}
 	
 	public Value agent(Value e){
+		if(e == null)
+			return null;
 		return _tbl.get(e);
 	}
 

--- a/sdf2table.core/src/main/java/org/metaborg/sdf2table/io/Importer.java
+++ b/sdf2table.core/src/main/java/org/metaborg/sdf2table/io/Importer.java
@@ -15,6 +15,7 @@ import org.metaborg.sdf2table.symbol.Alternative;
 import org.metaborg.sdf2table.symbol.CharClass;
 import org.metaborg.sdf2table.symbol.ContextFree;
 import org.metaborg.sdf2table.symbol.FileStart;
+import org.metaborg.sdf2table.symbol.Followed;
 import org.metaborg.sdf2table.symbol.Iteration;
 import org.metaborg.sdf2table.symbol.Layout;
 import org.metaborg.sdf2table.symbol.Lexical;
@@ -131,13 +132,7 @@ public class Importer{
 			case "Seq":
 				Terminal head = importTerminal(app.getSubterm(0));
 				for(CharClass tail : importLookaheadList(app.getSubterm(1))){
-					if(tail instanceof Sequence){
-						set.add(new Sequence(head, ((Sequence)tail).symbols()));
-					}else if(tail instanceof Terminal){
-						set.add(new Sequence(head, (Terminal)tail));
-					}else{
-						System.err.println("In sequence: `"+tail.toString()+"' is not a terminal.");
-					}
+					set.add(new Followed(head, (CharClass)tail));
 				}
 				break;
 			// TERMINALS
@@ -400,7 +395,7 @@ public class Importer{
 				symbol = new Alternative(importSymbol(null, app.getSubterm(0)), importSymbol(null, app.getSubterm(1)));
 				break;
 			case "Sequence":
-				symbol = new Sequence(importSymbol(null, app.getSubterm(0)), importSymbol(null, app.getSubterm(1)));
+				symbol = new Sequence(importSymbol(null, app.getSubterm(0)), importSymbolList(null, app.getSubterm(1)));
 				break;
 			case "Lex":
 				symbol = new Lexical(importSymbol(null, app.getSubterm(0)));

--- a/sdf2table.core/src/main/java/org/metaborg/sdf2table/io/Importer.java
+++ b/sdf2table.core/src/main/java/org/metaborg/sdf2table/io/Importer.java
@@ -435,7 +435,7 @@ public class Importer{
 			return null;
 		}
 		
-		if(collection != null)
+		if(collection != null && symbol != null)
 			symbol = collection.get(symbol, true);
 		
 		return symbol;

--- a/sdf2table.core/src/main/java/org/metaborg/sdf2table/parsetable/Item.java
+++ b/sdf2table.core/src/main/java/org/metaborg/sdf2table/parsetable/Item.java
@@ -15,8 +15,8 @@ import org.metaborg.sdf2table.grammar.Production;
 import org.metaborg.sdf2table.grammar.Trigger;
 import org.metaborg.sdf2table.grammar.UndefinedSymbolException;
 import org.metaborg.sdf2table.symbol.CharClass;
+import org.metaborg.sdf2table.symbol.Followed;
 import org.metaborg.sdf2table.symbol.NonTerminal;
-import org.metaborg.sdf2table.symbol.Sequence;
 import org.metaborg.sdf2table.symbol.Symbol;
 import org.metaborg.sdf2table.symbol.Terminal;
 
@@ -376,10 +376,10 @@ public class Item{
 					_reduce_actions.add(new Reduce(this, non_litigious, _prod.label()));
 				
 				for(CharClass cc : _prod.product().followRestrictions()){
-					if(cc instanceof Sequence){
+					if(cc instanceof Followed){
 						Terminal litigious = (Terminal)cc.firstTerminal().inter(t);
 						if(litigious != null){
-							_reduce_actions.add(new Reduce(this, litigious, _prod.label(), (Sequence)cc));
+							_reduce_actions.add(new Reduce(this, litigious, _prod.label(), Lookahead.fromCharClass(cc)));
 						}
 					}
 				}

--- a/sdf2table.core/src/main/java/org/metaborg/sdf2table/parsetable/Lookahead.java
+++ b/sdf2table.core/src/main/java/org/metaborg/sdf2table/parsetable/Lookahead.java
@@ -1,0 +1,36 @@
+package org.metaborg.sdf2table.parsetable;
+
+import java.util.List;
+
+import org.metaborg.sdf2table.core.Utilities;
+import org.metaborg.sdf2table.symbol.CharClass;
+import org.metaborg.sdf2table.symbol.Followed;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.terms.StrategoAppl;
+import org.spoofax.terms.StrategoConstructor;
+
+public class Lookahead{
+	private static final StrategoConstructor CONS_FOLLOW_RESTRICTION = new StrategoConstructor("follow-restriction", 1);
+	List<CharClass> _list = null;
+	
+	public Lookahead(List<CharClass> list){
+		_list = list;
+	}
+	
+	public static Lookahead fromCharClass(CharClass cc){
+		if(cc instanceof Followed){
+			List<CharClass> list = ((Followed)cc).symbols();
+			return new Lookahead(list.subList(1, list.size()));
+		}
+		return null;
+	}
+	
+	public IStrategoTerm toATerm(){
+		return Utilities.strategoListFromArray(new StrategoAppl(
+				CONS_FOLLOW_RESTRICTION,
+				new IStrategoTerm[]{Utilities.strategoListFromExportables(_list)},
+				null,
+				0
+		));
+	}
+}

--- a/sdf2table.core/src/main/java/org/metaborg/sdf2table/parsetable/ParseTable.java
+++ b/sdf2table.core/src/main/java/org/metaborg/sdf2table/parsetable/ParseTable.java
@@ -23,7 +23,6 @@ import org.metaborg.sdf2table.grammar.PriorityLevel;
 import org.metaborg.sdf2table.grammar.SyntaxProduction;
 import org.metaborg.sdf2table.grammar.Syntax;
 import org.metaborg.sdf2table.grammar.UndefinedSymbolException;
-import org.metaborg.sdf2table.io.Parenthesizer;
 import org.metaborg.sdf2table.symbol.NonTerminal;
 import org.metaborg.sdf2table.symbol.Symbol;
 import org.spoofax.interpreter.terms.*;

--- a/sdf2table.core/src/main/java/org/metaborg/sdf2table/parsetable/Reduce.java
+++ b/sdf2table.core/src/main/java/org/metaborg/sdf2table/parsetable/Reduce.java
@@ -1,19 +1,15 @@
 package org.metaborg.sdf2table.parsetable;
 
-import org.metaborg.sdf2table.core.Utilities;
 import org.metaborg.sdf2table.grammar.Production;
-import org.metaborg.sdf2table.symbol.Sequence;
 import org.metaborg.sdf2table.symbol.Terminal;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.terms.StrategoAppl;
 import org.spoofax.terms.StrategoConstructor;
 import org.spoofax.terms.StrategoInt;
-import org.spoofax.terms.StrategoList;
 
 public class Reduce extends Action{
 	private static final StrategoConstructor CONS_REDUCE = new StrategoConstructor("reduce", 3);
 	private static final StrategoConstructor CONS_REDUCE_LOOKAHEAD = new StrategoConstructor("reduce", 4);
-	private static final StrategoConstructor CONS_FOLLOW_RESTRICTION = new StrategoConstructor("follow-restriction", 1);
 	private static final StrategoInt APPL_NORMAL = new StrategoInt(0, null, 0);
 	private static final StrategoInt APPL_REJECT = new StrategoInt(1, null, 0);
 	private static final StrategoInt APPL_AVOID = new StrategoInt(2, null, 0);
@@ -29,7 +25,7 @@ public class Reduce extends Action{
 	
 	Label _label;
 	ReducePolicy _policy = ReducePolicy.NORMAL;
-	Sequence _lookahead;
+	Lookahead _lookahead;
 	Item _item;
 	
 	public Reduce(Item item, Terminal symbol, Label label){
@@ -40,7 +36,7 @@ public class Reduce extends Action{
 		selectReducePolicy();
 	}
 	
-	public Reduce(Item item, Terminal symbol, Label label, Sequence lookahead){
+	public Reduce(Item item, Terminal symbol, Label label, Lookahead lookahead){
 		super(symbol);
 		_label = label;
 		_lookahead = lookahead;
@@ -127,12 +123,7 @@ public class Reduce extends Action{
 							new StrategoInt(_label.agent().symbols().size(), null, 0),
 							new StrategoInt(_label.id(), null, 0),
 							aTermPolicy(),
-							Utilities.strategoListFromArray(new StrategoAppl(
-									CONS_FOLLOW_RESTRICTION,
-									new IStrategoTerm[]{((StrategoList)_lookahead.toATermList()).tail()},
-									null,
-									0
-							))
+							_lookahead.toATerm()
 					},
 					null,
 					0

--- a/sdf2table.core/src/main/java/org/metaborg/sdf2table/symbol/Alternative.java
+++ b/sdf2table.core/src/main/java/org/metaborg/sdf2table/symbol/Alternative.java
@@ -8,16 +8,21 @@ public class Alternative extends ConcreteNonTerminal{
 	private static final StrategoConstructor CONS_ALT = new StrategoConstructor("alt", 1);
 	
 	private Symbol _a, _b;
+	private Type _type = Type.TERMINAL;
 	
 	public Alternative(Symbol a, Symbol b){
 		super();
 		_a = a;
 		_b = b;
+		if(_a.type().level() > _type.level())
+			_type = _a.type();
+		if(_b.type().level() > _type.level())
+			_type = _b.type();
 	}
 	
 	@Override
 	public Type type(){
-		return Type.CONTEXT_FREE;
+		return _type;
 	}
 	
 	@Override

--- a/sdf2table.core/src/main/java/org/metaborg/sdf2table/symbol/Followed.java
+++ b/sdf2table.core/src/main/java/org/metaborg/sdf2table/symbol/Followed.java
@@ -1,0 +1,133 @@
+package org.metaborg.sdf2table.symbol;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.metaborg.sdf2table.core.Utilities;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.terms.StrategoAppl;
+import org.spoofax.terms.StrategoConstructor;
+import org.spoofax.terms.StrategoList;
+
+/**
+ * The "followed" charclass is the only character class that is not a Symbol.
+ * It can be seen as "the character c0 followed by c1 ... cn".
+ * <p>
+ * This is constructed from the ATerm "Seq" used in the "restrictions" section.
+ * This class has been introduced to deal with follow restrictions,
+ * where the restriction is about a sequence of characters.
+ * <p>
+ * Note that the method {@link #contains(int)} is slightly over-restrictive, in
+ * the sense that it returns true for a character c iff c = c0,
+ * even though c cannot be considered a a part of the caracter class
+ * c0c1..cn.
+ */
+public class Followed extends CharClass{
+	List<CharClass> _list = null;
+	//TODO Copied from the Sequence class, but I'm not sure it is useful anymore...
+	private static final StrategoConstructor CONS_SEQUENCE = new StrategoConstructor("sequence", 2);
+	
+	/**
+	 * Empty sequence constructor
+	 */
+	public Followed(){
+		_list = new ArrayList<>();
+	}
+	
+	public Followed(List<CharClass> list){
+		_list = list;
+	}
+	
+	public Followed(CharClass head, CharClass tail){
+		_list = new ArrayList<>();
+		_list.add(head);
+		if(tail instanceof Followed){
+			_list.addAll(((Followed)tail)._list);
+		}else{
+			_list.add(tail);
+		}
+	}
+	
+	public List<CharClass> symbols(){
+		return _list;
+	}
+	
+	@Override
+	public Terminal firstTerminal(){
+		if(_list.isEmpty())
+			return null;
+		return _list.get(0).getFirst();
+	}
+
+	@Override
+	public boolean contains(int c) {
+		return !_list.isEmpty() && firstTerminal().contains(c);
+	}
+	
+	@Override
+	public IStrategoTerm toATerm(){
+		//TODO Copied from the Sequence class, but I'm not sure it is useful anymore...
+		StrategoList slist = Utilities.strategoListFromExportables(_list);
+		
+		return new StrategoAppl(
+				CONS_SEQUENCE,
+				new IStrategoTerm[]{
+					slist.head(),
+					slist.tail()
+				},
+				null,
+				0
+		);
+	}
+	
+	public StrategoList toATermList() {
+		return Utilities.strategoListFromExportables(_list);
+	}
+
+	@Override
+	public int minimum() {
+		if(_list.isEmpty())
+			return 256;
+		return firstTerminal().minimum();
+	}
+
+	@Override
+	public int maximum() {
+		if(_list.isEmpty())
+			return 256;
+		return firstTerminal().maximum();
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		if(other != null && other instanceof Sequence){
+			Sequence s = (Sequence)other;
+			if(s._list.size() == _list.size()){
+				for(int i = 0; i < _list.size(); ++i){
+					if(!s._list.get(i).equals(_list.get(i)))
+						return false;
+				}
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public String toString() {
+		String str = "";
+		for(Symbol t : _list){
+			if(!str.isEmpty())
+				str += ".";
+			str += t.toString();
+		}
+		return str;
+	}
+
+	@Override
+	public Terminal getFirst() {
+		if(_list.isEmpty())
+			return null;
+		return _list.get(0).getFirst();
+	}
+}

--- a/sdf2table.core/src/main/java/org/metaborg/sdf2table/symbol/Iteration.java
+++ b/sdf2table.core/src/main/java/org/metaborg/sdf2table/symbol/Iteration.java
@@ -23,7 +23,7 @@ public class Iteration extends ConcreteNonTerminal{
 	
 	@Override
 	public Type type(){
-		return Type.CONTEXT_FREE;
+		return _symbol.type();
 	}
 	
 	@Override

--- a/sdf2table.core/src/main/java/org/metaborg/sdf2table/symbol/Option.java
+++ b/sdf2table.core/src/main/java/org/metaborg/sdf2table/symbol/Option.java
@@ -21,7 +21,7 @@ public class Option extends ConcreteNonTerminal {
 	
 	@Override
 	public Type type(){
-		return Type.CONTEXT_FREE;
+		return _symbol.type();
 	}
 	
 	public Symbol getSymbol(){

--- a/sdf2table.core/src/main/java/org/metaborg/sdf2table/symbol/Sequence.java
+++ b/sdf2table.core/src/main/java/org/metaborg/sdf2table/symbol/Sequence.java
@@ -11,6 +11,7 @@ import org.spoofax.terms.StrategoList;
 
 public class Sequence extends ConcreteNonTerminal{
 	List<Symbol> _list = null;
+	Type _type = Type.TERMINAL;
 	private static final StrategoConstructor CONS_SEQUENCE = new StrategoConstructor("sequence", 2);
 	
 	/**
@@ -22,12 +23,21 @@ public class Sequence extends ConcreteNonTerminal{
 	
 	public Sequence(List<Symbol> list){
 		_list = list;
+		initType();
 	}
 	
 	public Sequence(Symbol head, List<Symbol> tail){
 		_list = new ArrayList<>();
 		_list.add(head);
 		_list.addAll(tail);
+		initType();
+	}
+	
+	void initType(){
+		for(Symbol s : _list){
+			if(s.type().level() > _type.level())
+				_type = s.type();
+		}
 	}
 	
 	public List<Symbol> symbols(){
@@ -78,7 +88,7 @@ public class Sequence extends ConcreteNonTerminal{
 
 	@Override
 	public Type type() {
-		return Type.CONTEXT_FREE;
+		return _type;
 	}
 
 	@Override

--- a/sdf2table.core/src/main/java/org/metaborg/sdf2table/symbol/Sequence.java
+++ b/sdf2table.core/src/main/java/org/metaborg/sdf2table/symbol/Sequence.java
@@ -9,19 +9,7 @@ import org.spoofax.terms.StrategoAppl;
 import org.spoofax.terms.StrategoConstructor;
 import org.spoofax.terms.StrategoList;
 
-/**
- * The sequence is the only character class that is not a Symbol.
- * It can be seen as "the character c0 followed by c1 ... cn".
- * <p>
- * This class has been introduced to deal with follow restrictions,
- * where the restriction is about a sequence of characters.
- * <p>
- * Note that the method {@link #contains(int)} is slightly over-restrictive, in
- * the sense that it returns true for a character c iff c = c0,
- * even though c cannot be considered a a part of the caracter class
- * c0c1..cn.
- */
-public class Sequence extends CharClass{
+public class Sequence extends ConcreteNonTerminal{
 	List<Symbol> _list = null;
 	private static final StrategoConstructor CONS_SEQUENCE = new StrategoConstructor("sequence", 2);
 	
@@ -36,12 +24,6 @@ public class Sequence extends CharClass{
 		_list = list;
 	}
 	
-	public Sequence(Symbol head, Symbol tail){
-		_list = new ArrayList<>();
-		_list.add(head);
-		_list.add(tail);
-	}
-	
 	public Sequence(Symbol head, List<Symbol> tail){
 		_list = new ArrayList<>();
 		_list.add(head);
@@ -50,18 +32,6 @@ public class Sequence extends CharClass{
 	
 	public List<Symbol> symbols(){
 		return _list;
-	}
-	
-	@Override
-	public Terminal firstTerminal(){
-		if(_list.isEmpty())
-			return null;
-		return _list.get(0).getFirst();
-	}
-
-	@Override
-	public boolean contains(int c) {
-		return !_list.isEmpty() && firstTerminal().contains(c);
 	}
 	
 	@Override
@@ -77,24 +47,6 @@ public class Sequence extends CharClass{
 				null,
 				0
 		);
-	}
-	
-	public StrategoList toATermList() {
-		return Utilities.strategoListFromExportables(_list);
-	}
-
-	@Override
-	public int minimum() {
-		if(_list.isEmpty())
-			return 256;
-		return firstTerminal().minimum();
-	}
-
-	@Override
-	public int maximum() {
-		if(_list.isEmpty())
-			return 256;
-		return firstTerminal().maximum();
 	}
 
 	@Override
@@ -114,19 +66,37 @@ public class Sequence extends CharClass{
 
 	@Override
 	public String toString() {
-		String str = "";
+		String str = "(";
 		for(Symbol t : _list){
 			if(!str.isEmpty())
-				str += ".";
+				str += " ";
 			str += t.toString();
 		}
+		str += ")";
 		return str;
 	}
 
 	@Override
-	public Terminal getFirst() {
-		if(_list.isEmpty())
-			return null;
-		return _list.get(0).getFirst();
+	public Type type() {
+		return Type.CONTEXT_FREE;
+	}
+
+	@Override
+	public boolean nonEpsilon(){
+		for(Symbol s : _list){
+			if(s.nonEpsilon())
+				return true;
+		}
+		return false;
+	}
+	
+	@Override
+	public boolean isLayout() {
+		for(Symbol s : _list){
+			if(!s.isLayout())
+				return false;
+		}
+		
+		return true;
 	}
 }

--- a/sdf2table.core/src/main/java/org/metaborg/sdf2table/symbol/SymbolCollection.java
+++ b/sdf2table.core/src/main/java/org/metaborg/sdf2table/symbol/SymbolCollection.java
@@ -10,8 +10,6 @@ public class SymbolCollection {
 	}
 	
 	public Symbol get(Symbol symbol){
-		if(symbol == null)
-			return null;
 		Symbol s =_symbols.agent(symbol);
 		return s;
 	}
@@ -21,10 +19,8 @@ public class SymbolCollection {
 	}
 	
 	public Symbol get(Symbol symbol, boolean create){
-		if(symbol == null)
-			return null;
 		Symbol s = get(symbol);
-		if(s == null && create)
+		if(s == null && symbol != null && create)
 			_symbols.add(s = symbol);
 		return s;
 	}

--- a/sdf2table.core/src/main/java/org/metaborg/sdf2table/symbol/SymbolCollection.java
+++ b/sdf2table.core/src/main/java/org/metaborg/sdf2table/symbol/SymbolCollection.java
@@ -10,6 +10,8 @@ public class SymbolCollection {
 	}
 	
 	public Symbol get(Symbol symbol){
+		if(symbol == null)
+			return null;
 		Symbol s =_symbols.agent(symbol);
 		return s;
 	}
@@ -19,6 +21,8 @@ public class SymbolCollection {
 	}
 	
 	public Symbol get(Symbol symbol, boolean create){
+		if(symbol == null)
+			return null;
 		Symbol s = get(symbol);
 		if(s == null && create)
 			_symbols.add(s = symbol);


### PR DESCRIPTION
I'm just considering the following things now:
- CollisionSet: We can try to get the agent of a null pointer (now it returns null).
- Importer: A symbol (`Absent`) can be imported as the null pointer. No need to request a unique pointer from the symbol collection then. null is null.
- SymbolCollection: The null pointer cannot be added to the collection.