### PR TITLE
Make symbol in character class accessible

### DIFF
--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/CharacterClass.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/CharacterClass.java
@@ -25,6 +25,10 @@ public class CharacterClass extends Symbol {
         this.cc = s;
     }
 
+    public Symbol symbol() {
+        return cc;
+    }
+
     public static CharacterClass union(CharacterClass... ary) {
         int _min = minimum(ary);
         int _max = maximum(ary);

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/CharacterClassConc.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/CharacterClassConc.java
@@ -23,6 +23,14 @@ public class CharacterClassConc extends Symbol {
         this.second = second;
     }
 
+    public Symbol first() {
+        return first;
+    }
+
+    public Symbol second() {
+        return second;
+    }
+
     public String name() {
         return first.name() + second.name();
     }

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/CharacterClassRange.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/CharacterClassRange.java
@@ -19,6 +19,14 @@ public class CharacterClassRange extends Symbol {
         this.end = iSymbol2;
     }
 
+    public Symbol start() {
+        return start;
+    }
+
+    public Symbol end() {
+        return end;
+    }
+
     public String name() {
         return start.name() + "-" + end.name();
     }

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/IterSepSymbol.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/IterSepSymbol.java
@@ -22,6 +22,10 @@ public class IterSepSymbol extends Symbol {
         followRestrictions = Sets.newHashSet();
     }
 
+    public Symbol getSymbol() {
+        return symbol;
+    }
+
     @Override public String name() {
         return "{" + symbol.name() + " " + sep.name() + "}+";
     }

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/IterSymbol.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/IterSymbol.java
@@ -20,6 +20,10 @@ public class IterSymbol extends Symbol {
         followRestrictions = Sets.newHashSet();
     }
 
+    public Symbol getSymbol() {
+        return symbol;
+    }
+
     @Override public String name() {
         return symbol.name() + "+";
     }

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/OptionalSymbol.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/OptionalSymbol.java
@@ -20,6 +20,10 @@ public class OptionalSymbol extends Symbol {
         followRestrictions = Sets.newHashSet();
     }
     
+    public Symbol getSymbol() {
+        return symbol;
+    }
+
     @Override public String name() {
         return symbol.name() + "?";
     }


### PR DESCRIPTION
@udesou are you willing to merge these changes? This exposes the underlying symbol in the symbol classes. Some classes already had a `getSymbol` method, others were lacking access to their underlying symbol.