### PR TITLE
Fix three bugs in the parse table reader

### DIFF
--- a/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/productions/ProductionReader.java
+++ b/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/productions/ProductionReader.java
@@ -169,6 +169,7 @@ public class ProductionReader {
                         type = ProductionType.AVOID;
                         break;
                     case "bracket":
+                    case "deprecated":
                         // Irrelevant during parsing/imploding thus we ignore it here.
                         break;
                     case "assoc":

--- a/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/symbols/ISequenceSymbol.java
+++ b/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/symbols/ISequenceSymbol.java
@@ -1,4 +1,9 @@
 package org.metaborg.parsetable.symbols;
 
+import java.util.List;
+
 public interface ISequenceSymbol extends INonTerminalSymbol {
+
+    List<ISymbol> symbols();
+
 }

--- a/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/symbols/SequenceSymbol.java
+++ b/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/symbols/SequenceSymbol.java
@@ -1,9 +1,14 @@
 package org.metaborg.parsetable.symbols;
 
+import java.util.List;
+
 public class SequenceSymbol extends NonTerminalSymbol implements ISequenceSymbol {
 
-    public SequenceSymbol(SyntaxContext syntaxContext) {
-        super(syntaxContext, SortCardinality.Seq);
+    private List<ISymbol> symbols;
+
+    public SequenceSymbol(SyntaxContext syntaxContext, SortCardinality cardinality, List<ISymbol> symbols) {
+        super(syntaxContext, cardinality);
+        this.symbols = symbols;
     }
 
     @Override public ConcreteSyntaxContext concreteSyntaxContext() {
@@ -12,5 +17,9 @@ public class SequenceSymbol extends NonTerminalSymbol implements ISequenceSymbol
 
     @Override public String descriptor() {
         return "seq";
+    }
+
+    @Override public List<ISymbol> symbols() {
+        return symbols;
     }
 }

--- a/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/symbols/SortCardinality.java
+++ b/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/symbols/SortCardinality.java
@@ -2,7 +2,6 @@ package org.metaborg.parsetable.symbols;
 
 public enum SortCardinality {
     Optional("opt", true, false),
-    Seq("seq", true, false),
     Iter("iter", false, true),
     IterSep("iter-sep", false, true),
     IterStar("iter-star", false, true),

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/SequenceSymbol.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/SequenceSymbol.java
@@ -1,9 +1,9 @@
 package org.metaborg.sdf2table.grammar;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 
 import org.metaborg.parsetable.symbols.ISymbol;
 import org.metaborg.parsetable.symbols.SortCardinality;
@@ -21,7 +21,7 @@ public class SequenceSymbol extends Symbol {
     private final Symbol first;
     private final List<Symbol> tail;
 
-    public SequenceSymbol(Symbol first, List<Symbol> tail) {        
+    public SequenceSymbol(Symbol first, List<Symbol> tail) {
         this.first = first;
         this.tail = tail;
         followRestrictionsLookahead = Lists.newArrayList();
@@ -42,23 +42,23 @@ public class SequenceSymbol extends Symbol {
 
     @Override public IStrategoTerm toAterm(ITermFactory tf) {
         List<IStrategoTerm> tail_aterm = Lists.newArrayList();
-    
+
         for(Symbol s : tail) {
             tail_aterm.add(s.toAterm(tf));
         }
-    
+
         return tf.makeAppl(tf.makeConstructor("seq", 2), first.toAterm(tf), tf.makeList(tail_aterm));
     }
 
-    @Override public IStrategoTerm toSDF3Aterm(ITermFactory tf,
-        Map<Set<Context>, Integer> ctx_vals, Integer ctx_val) {
+    @Override public IStrategoTerm toSDF3Aterm(ITermFactory tf, Map<Set<Context>, Integer> ctx_vals, Integer ctx_val) {
         List<IStrategoTerm> tail_aterm = Lists.newArrayList();
-        
+
         for(Symbol s : tail) {
             tail_aterm.add(s.toSDF3Aterm(tf, ctx_vals, ctx_val));
         }
-    
-        return tf.makeAppl(tf.makeConstructor("Sequence", 2), first.toSDF3Aterm(tf, ctx_vals, ctx_val), tf.makeList(tail_aterm));
+
+        return tf.makeAppl(tf.makeConstructor("Sequence", 2), first.toSDF3Aterm(tf, ctx_vals, ctx_val),
+            tf.makeList(tail_aterm));
     }
 
     @Override public int hashCode() {
@@ -91,6 +91,13 @@ public class SequenceSymbol extends Symbol {
     }
 
     @Override public ISymbol toParseTableSymbol(SyntaxContext syntaxContext, SortCardinality cardinality) {
-        return new org.metaborg.parsetable.symbols.SequenceSymbol(syntaxContext);
+        List<ISymbol> symbols = new ArrayList<>();
+
+        symbols.add(first.toParseTableSymbol(syntaxContext, cardinality));
+        for(Symbol tailSymbol : tail) {
+            symbols.add(tailSymbol.toParseTableSymbol(syntaxContext, cardinality));
+        }
+
+        return new org.metaborg.parsetable.symbols.SequenceSymbol(syntaxContext, cardinality, symbols);
     }
 }


### PR DESCRIPTION
- The production attribute "deprecated" is now properly ignored (instead of throwing an exception when encountering it)
  - Apparently, this attribute is used in (the parse table of) NaBL2. @jasperdenkers should it really be ignored or should this result in a warning somewhere?
- The order of SyntaxContext and SortCardinality no longer matters (e.g. both `cf(iter(...))` and `iter(cf(...))` are accepted now)
  - The quick and dirty solution here is to check for the SyntaxContext again after checking for the SortCardinality.
- A sequence symbol is now properly read, including its subterms
  - Note: apparently the GreenMarl parse table from the integration tests has `seq` represented with just a list (`seq([...])`) instead of using a `first` and `tail` (`seq(..., [...])`). I don't know why, but I've made sure that both are accepted.