### PR TITLE
Fix character classes

### DIFF
--- a/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/characterclasses/CharacterClassRangeSet.java
+++ b/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/characterclasses/CharacterClassRangeSet.java
@@ -79,7 +79,7 @@ public final class CharacterClassRangeSet implements ICharacterClass, Serializab
     }
 
     @Override public boolean isEmpty() {
-        return rangeSet.isEmpty() && !containsEOF;
+        return Arrays.equals(words, EMPTY_WORDS_ARRAY) && !containsEOF;
     }
 
     @Override public ICharacterClass union(ICharacterClass other) {

--- a/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/characterclasses/CharacterClassRangeSet.java
+++ b/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/characterclasses/CharacterClassRangeSet.java
@@ -18,8 +18,7 @@ public final class CharacterClassRangeSet implements ICharacterClass, Serializab
 
     private static final long serialVersionUID = 8553734625129300348L;
 
-    protected static final int BITMAP_SEGMENT_SIZE = 6; // 2^6 = 64 = 1/4 * 256
-
+    static final int BITMAP_SEGMENT_SIZE = 6; // 2^6 = 64 = 1/4 * 256
     static final long[] EMPTY_WORDS_ARRAY = new long[4];
     static final CharacterClassRangeSet EMPTY_CONSTANT = new CharacterClassRangeSet();
 
@@ -52,7 +51,6 @@ public final class CharacterClassRangeSet implements ICharacterClass, Serializab
             this.words = EMPTY_WORDS_ARRAY;
         else
             this.words = Arrays.copyOf(convertToBitSet().toLongArray(), 4);
-        assert this.words != null;
     }
 
     @Override public final boolean contains(int character) {


### PR DESCRIPTION
Apparently, empty character classes (in the form of `[]`) ended up in the parse table ATerm. The cause of this was a `CharacterClassRangeSet` that was empty, but did not get flagged as empty by the `isEmpty` method. In this particular case, the range set contained one range, namely `<47,48>` (note how both end points are _exclusive_), which still resulted in an empty character class.

Besides doing some refactoring, I've made sure that the `CharacterClassRangeSet.isEmpty` check actually checks whether the set is empty ([link](https://github.com/metaborg/sdf/pull/31/files#diff-d6390a0bdbcb54e65316fee87103f314L92-R82)).