### PR TITLE
Let ISymbol.getSort only return a sort if it has no cardinality

### DIFF
--- a/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/symbols/ISymbol.java
+++ b/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/symbols/ISymbol.java
@@ -11,7 +11,14 @@ public interface ISymbol {
     String descriptor();
 
     static String getSort(ISymbol symbol) {
-        return symbol instanceof ISortSymbol ? ((ISortSymbol) symbol).sort() : null;
+        if(!(symbol instanceof ISortSymbol)) {
+            return null;
+        }
+        ISortSymbol sortSymbol = (ISortSymbol) symbol;
+        if(sortSymbol.cardinality() == null) {
+            return sortSymbol.sort();
+        }
+        return null;
     }
 
 }


### PR DESCRIPTION
See metaborg/jsglr#57.

Calling `getSort` on a list/optional/etc symbol from a parse table taken directly from SDF3 generation used to return `null`, but calling `getSort` on the same sort of a serialized-and-deserialized parse table would return the base sort.

[The following code](https://github.com/metaborg/sdf/blob/cd53152dfd66440fcf17d431d2b5bc87ca04365d/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/Symbol.java#L110-L121) is used in the generated parse table to determine the sort:
```java
    public static String getSort(ISymbol s) {
        if(s instanceof Sort && ((Sort) s).getType() == null) {
            return s.name();
        } else if(s instanceof ContextFreeSymbol) {
            return getSort(((ContextFreeSymbol) s).getSymbol());
        } else if(s instanceof LexicalSymbol) {
            return getSort(((LexicalSymbol) s).getSymbol());
        } else if(s instanceof AltSymbol) {
            return getSort(((AltSymbol) s).left()) + "_" + getSort(((AltSymbol) s).right());
        }
        return null;
    }
```
In other words: only if a symbol is a sort (either lexical, context-free, or neither (kernel syntax)) or if a symbol is an `AltSymbol`, a sort is returned. Else, `null` is returned.

In this PR, I changed the `symbol instanceof ISortSymbol ? ((ISortSymbol) symbol).sort() : null` of the deserialized parse table implementation to more closely match the behaviour of the first implementation (at least to the degree that the integration tests pass; I'm sure that the behaviour for untested symbols can still be inconsistent).

@jasperdenkers I can imagine that both of these behaviours may or may not be desirable. A third option is: I would expect the sort of a "symbol with cardinality" to incorporate the cardinality operators (e.g. `Exp+` or `Exp?`). This can get quite complicated (e.g. I can think of `{(Exp | Stmt) ";"}+`), and I'm not sure whether there is a use case for this. For example, ESV can only target "base sorts" for coloring because sorts can only have letters there.