### PR TITLE
Add generator for rudimentary TextMate grammar

### DIFF
--- a/org.metaborg.meta.lang.template/editor/Menus.esv
+++ b/org.metaborg.meta.lang.template/editor/Menus.esv
@@ -57,7 +57,10 @@ menus
     
     action: "Generate PP (abstract)" = generate-pp-abstract (meta)
     action: "Generate PP"            = generate-pp-concrete
-          	
+        
+    submenu: "Misc"
+      action: "Generate TextMate grammar"          = generate-textmate-grammar
+    end
 //    action: "Generate AST checker (abstract)" = generate-ast-checker-abstract (meta)
 //    action: "Generate AST checker"            = generate-ast-checker-concrete
          

--- a/org.metaborg.meta.lang.template/trans/editor/build-misc.str
+++ b/org.metaborg.meta.lang.template/trans/editor/build-misc.str
@@ -1,0 +1,16 @@
+module editor/build-misc
+
+imports
+  libstrc
+  signatures/TemplateLang-sig
+  signatures/modules/Modules-sig
+  analysis/desugar
+  editor/build-utils
+  generation/textmate/-
+
+rules
+
+  generate-textmate-grammar:
+    (selected, position, ast, path, project-path) -> ("test.tm", result)
+    where 
+      result := <to-textmate(|project-path, path)> ast

--- a/org.metaborg.meta.lang.template/trans/editor/build-misc.str
+++ b/org.metaborg.meta.lang.template/trans/editor/build-misc.str
@@ -11,6 +11,6 @@ imports
 rules
 
   generate-textmate-grammar:
-    (selected, position, ast, path, project-path) -> ("test.tm", result)
+    (selected, position, ast, path, project-path) -> ("spoofaxlang.tmLanguage.json", result)
     where 
       result := <to-textmate(|project-path, path)> ast

--- a/org.metaborg.meta.lang.template/trans/generation/textmate/gen-textmate-grammar.str
+++ b/org.metaborg.meta.lang.template/trans/generation/textmate/gen-textmate-grammar.str
@@ -123,9 +123,6 @@ rules
 				},{
 					"name": "keyword.operator.<langid>",
 					"match": "(<<map(escape-for-regex); separate-by(|"|"); concat-strings; escape-for-json> operators>)"
-				},{
-					"name": "punctuation.separator.delimiter.<langid>",
-					"match": "()"
 				}]
 			},
 			"identifiers": {

--- a/org.metaborg.meta.lang.template/trans/generation/textmate/gen-textmate-grammar.str
+++ b/org.metaborg.meta.lang.template/trans/generation/textmate/gen-textmate-grammar.str
@@ -1,0 +1,46 @@
+module generation/textmate/gen-textmate-grammar
+
+imports 
+  libstratego-sglr
+  libstratego-lib
+  libspoofax/resource/cache
+  libspoofax/stratego/debug
+  generation/gen-utils/remove-template
+  generation/syntax/gen-exp-grammars
+  
+imports
+  signatures/aliases/-
+  signatures/aterms/-
+  signatures/basic/-
+  signatures/characterclass/-
+  signatures/constants/-
+  signatures/grammar/-
+  signatures/kernel/-
+  signatures/labels/-
+  signatures/layout/-
+  signatures/layout-constraints/-
+  signatures/lifting/-
+  signatures/literals/-
+  signatures/modules/-
+  signatures/priority/-
+  signatures/regular/-
+  signatures/renaming/-
+  signatures/restrictions/-
+  signatures/sdf2-core/-
+  signatures/sorts/-
+  signatures/symbols/-
+  signatures/TemplateLang-sig
+  
+rules
+
+   to-textmate(|project-path, path):
+     m@Module(Unparameterized(mn), i*, sections*) -> imp-asts*
+     where
+       name' := <strip-annos> mn;  
+       rules(expanded-module: name' -> <id>)
+     where
+       dir            := <dirname> path;
+       i'*            := <mapconcat(?Imports(<id>))> i*;
+       imp-asts*      := <filter(?Module(Unparameterized(<id>)); expand-import(|project-path, dir)); flatten-list> i'*
+       
+       

--- a/org.metaborg.meta.lang.template/trans/generation/textmate/gen-textmate-grammar.str
+++ b/org.metaborg.meta.lang.template/trans/generation/textmate/gen-textmate-grammar.str
@@ -42,7 +42,9 @@ rules
        dir            := <dirname> path;
        i'*            := <mapconcat(?Imports(<id>))> i*;
        imp-asts*      := <filter(?Module(Unparameterized(<id>)); expand-import(|project-path, dir)); flatten-list> i'*;
-       result := (<get-keywords> imp-asts*, <get-operators> imp-asts*)
+       keywords       := <get-keywords> imp-asts*;
+       operators      := <get-operators> imp-asts*;
+       result         := <to-textmate-string(|"Spoofax Language", "spoofaxlang")> (operators, keywords)
     
     get-keywords = collect-all(get-keyword)
     get-keyword: String(x) -> <is-keyword> x
@@ -51,12 +53,104 @@ rules
     get-operator: String(x) -> <not(is-keyword)> x
     
     is-keyword = where(explode-string; [is-alpha + ?'_' | map(is-alphanum + ?'_' + ?'-') ])
-       
-	// extract:
-	// - single line comments
-	// - multi line comments
-	// - string literals (and escapes)
-	// - number literal
-	// - identifiers
-	// - keywords
-	// - operators
+    
+    escape-for-regex = string-as-chars(escape-chars(
+    	  \['-'|cs] -> ['\', '-'|cs]\
+    	+ \['['|cs] -> ['\', '['|cs]\
+    	+ \[']'|cs] -> ['\', ']'|cs]\
+    	+ \['{'|cs] -> ['\', '{'|cs]\
+    	+ \['}'|cs] -> ['\', '}'|cs]\
+    	+ \['('|cs] -> ['\', '('|cs]\
+    	+ \[')'|cs] -> ['\', ')'|cs]\
+    	+ \['*'|cs] -> ['\', '*'|cs]\
+    	+ \['+'|cs] -> ['\', '+'|cs]\
+    	+ \['?'|cs] -> ['\', '?'|cs]\
+    	+ \['.'|cs] -> ['\', '.'|cs]\
+    	+ \[','|cs] -> ['\', ','|cs]\
+    	+ \['\'|cs] -> ['\', '\'|cs]\
+    	+ \['^'|cs] -> ['\', '^'|cs]\
+    	+ \['$'|cs] -> ['\', '$'|cs]\
+    	+ \['|'|cs] -> ['\', '|'|cs]\
+    	+ \['#'|cs] -> ['\', '#'|cs]\
+    	+ \[' '|cs] -> ['\', ' '|cs]\
+    ))
+    
+    escape-for-json = string-as-chars(escape-chars(
+    	  \['\'|cs] -> ['\', '\'|cs]\
+    	+ \['"'|cs] -> ['\', '"'|cs]\
+    	+ \['\t'|cs] -> ['\', 't'|cs]\
+    	+ \['\n'|cs] -> ['\', 'n'|cs]\
+    	+ \['\r'|cs] -> ['\', 'r'|cs]\
+    ))
+      
+	// TODO: extract:
+	// - single line comment start sequence
+	// - multi line comment start and end sequence
+	// - string start and end sequence (and escape sequences)
+	// - number literal sequences
+	// - identifier sequences
+	
+	to-textmate-string(|langname, langid): (operators, keywords) -> $<{
+		"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+		"name": "<langname>",
+		"patterns": [
+			{ "include": "#comments" },
+			{ "include": "#keywords" },
+			{ "include": "#identifiers" },
+			{ "include": "#constructors" },
+			{ "include": "#strings" }
+		],
+		"repository": {
+			"comments": {
+				"patterns": [{
+					"name": "comment.line.<langid>",
+					"match": "//.*$"
+				},{
+					"name": "comment.block.<langid>",
+					"begin": "/\\*",
+					"end": "\\*/\\n?",
+					"captures": {
+						"0": {
+							"name": "punctuation.definition.comment.<langid>"
+						}
+					}
+				}]
+			},
+			"keywords": {
+				"patterns": [{
+					"name": "keyword.<langid>",
+					"match": "\\b(<<map(escape-for-regex); separate-by(|"|"); concat-strings; escape-for-json> keywords>)\\b"
+				},{
+					"name": "keyword.operator.<langid>",
+					"match": "(<<map(escape-for-regex); separate-by(|"|"); concat-strings; escape-for-json> operators>)"
+				},{
+					"name": "punctuation.separator.delimiter.<langid>",
+					"match": "()"
+				}]
+			},
+			"identifiers": {
+				"patterns": [{
+					"name": "entity.name.<langid>",
+					"match": "\\b[a-z][a-zA-Z0-9_\\-']*\\b"
+				}]
+			},
+			"constructors": {
+				"patterns": [{
+					"name": "entity.name.type.<langid>",
+					"match": "\\b[A-Z][a-zA-Z0-9_\\-']*\\b"
+				}]
+			},
+			"strings": {
+				"name": "string.quoted.double.<langid>",
+				"begin": "\"",
+				"end": "\"",
+				"patterns": [
+					{
+						"name": "constant.character.escape.<langid>",
+						"match": "\\\\."
+					}
+				]
+			}
+		},
+		"scopeName": "source.<langid>"
+	}>

--- a/org.metaborg.meta.lang.template/trans/generation/textmate/gen-textmate-grammar.str
+++ b/org.metaborg.meta.lang.template/trans/generation/textmate/gen-textmate-grammar.str
@@ -42,8 +42,9 @@ rules
        dir            := <dirname> path;
        i'*            := <mapconcat(?Imports(<id>))> i*;
        imp-asts*      := <filter(?Module(Unparameterized(<id>)); expand-import(|project-path, dir)); flatten-list> i'*;
-       keywords       := <get-keywords> imp-asts*;
-       operators      := <get-operators> imp-asts*;
+       asts           := <![m | imp-asts*]>;
+       keywords       := <get-keywords> asts;
+       operators      := <get-operators> asts;
        result         := <to-textmate-string(|"Spoofax Language", "spoofaxlang")> (operators, keywords)
     
     get-keywords = collect-all(get-keyword)

--- a/org.metaborg.meta.lang.template/trans/generation/textmate/gen-textmate-grammar.str
+++ b/org.metaborg.meta.lang.template/trans/generation/textmate/gen-textmate-grammar.str
@@ -34,13 +34,29 @@ imports
 rules
 
    to-textmate(|project-path, path):
-     m@Module(Unparameterized(mn), i*, sections*) -> imp-asts*
+     m@Module(Unparameterized(mn), i*, sections*) -> result
      where
        name' := <strip-annos> mn;  
        rules(expanded-module: name' -> <id>)
      where
        dir            := <dirname> path;
        i'*            := <mapconcat(?Imports(<id>))> i*;
-       imp-asts*      := <filter(?Module(Unparameterized(<id>)); expand-import(|project-path, dir)); flatten-list> i'*
+       imp-asts*      := <filter(?Module(Unparameterized(<id>)); expand-import(|project-path, dir)); flatten-list> i'*;
+       result := (<get-keywords> imp-asts*, <get-operators> imp-asts*)
+    
+    get-keywords = collect-all(get-keyword)
+    get-keyword: String(x) -> <is-keyword> x
+    
+    get-operators = collect-all(get-operator)
+    get-operator: String(x) -> <not(is-keyword)> x
+    
+    is-keyword = where(explode-string; [is-alpha + ?'_' | map(is-alphanum + ?'_' + ?'-') ])
        
-       
+	// extract:
+	// - single line comments
+	// - multi line comments
+	// - string literals (and escapes)
+	// - number literal
+	// - identifiers
+	// - keywords
+	// - operators

--- a/org.metaborg.meta.lang.template/trans/templatelang.str
+++ b/org.metaborg.meta.lang.template/trans/templatelang.str
@@ -30,12 +30,14 @@ imports
   editor/build-sig
   editor/build-syntax
   editor/build-utils
+  editor/build-misc
   names/analysis/names
   types/analysis/types-ts
   generation/completion/-
   generation/pp/-
   generation/signatures/-
   generation/syntax/-
+  generation/textmate/-
 
 
 


### PR DESCRIPTION
TextMate grammars are supported for syntax highlighting in various editors, including VS Code, Atom, IntelliJ, Eclipse, and Theia. They use line-based Oniguruma regular expressions, but are very limited in the kinds of syntax highlighting they can express. While they do support recursive syntactic definitions, TextMate grammars are not powerful enough to perform sound highlighting for SGLR grammars.

This pull request adds to SDF3 a generator that can produce a rudimentary TextMate grammar for the language. The TextMate grammar performs syntax highlighting of the language's keywords and operators, and currently assumes C-style comments and string literals. Future work could include: expanding the TextMate grammar by performing heuristics on the SDF grammar; or, explicitly annotating the SDF grammar with the various kinds of tokens (comments, literals, keywords).

For now, this rudimentary TextMate grammar generator is enough to perform basic (unsound) syntax highlighting of the language's keywords, operators, literals and comments in other supported editors, making it easier to read the language. As an example: a [VS Code plugin for Ministatix](https://github.com/Virtlink/ministatix-vscode) is built around the generated TextMate grammar.