### PR TITLE
Non-layout token break support

### DIFF
--- a/org.metaborg.meta.lang.template/syntax/TemplateLang.sdf3
+++ b/org.metaborg.meta.lang.template/syntax/TemplateLang.sdf3
@@ -98,8 +98,10 @@ SortCons.SortCons = <<SymbolDef>.<Constructor>>
 
  
 // placeholders
-TemplatePart1.Angled = <\<<Placeholder>\>>
-TemplatePart2.Squared = <[<Placeholder>]>
+TemplatePart1.Angled       = [<[Placeholder]>]
+TemplatePart1.BreakAngled  = [<>] {avoid}
+TemplatePart2.Squared      = <[<Placeholder>]>
+TemplatePart2.BreakSquared = <[]> {avoid}
 
 Placeholder.Placeholder = <<Symbol><PlaceholderOptions>>
 

--- a/org.metaborg.meta.lang.template/syntax/TemplateLang.sdf3
+++ b/org.metaborg.meta.lang.template/syntax/TemplateLang.sdf3
@@ -99,9 +99,9 @@ SortCons.SortCons = <<SymbolDef>.<Constructor>>
  
 // placeholders
 TemplatePart1.Angled       = [<[Placeholder]>]
-TemplatePart1.BreakAngled  = [<>] {avoid}
+TemplatePart1.BreakAngled  = [<>]
 TemplatePart2.Squared      = <[<Placeholder>]>
-TemplatePart2.BreakSquared = <[]> {avoid}
+TemplatePart2.BreakSquared = <[]>
 
 Placeholder.Placeholder = <<Symbol><PlaceholderOptions>>
 

--- a/org.metaborg.meta.lang.template/trans/analysis/desugar.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/desugar.str
@@ -46,13 +46,13 @@ rules
   desugar-template:
     SingleLineTemplate(elem*) -> SingleLineTemplate(elem'*)
     with
-      elem'* := <desugar-elements> elem* 
+      elem'* := <desugar-elements; filter-breaks> elem* 
 
   //desugar templates with one line into a single line template
   desugar-template:
     <?Template([Line(elem*)]) + ?TemplateSquare([Line(elem*)]) + ?TemplateDeprecated([Line(elem*)]) + ?TemplateSquareDeprecated([Line(elem*)])> -> SingleLineTemplate(elem'*)
     with
-      elem'* := <desugar-elements; concatenate-consecutive-strings> elem* 
+      elem'* := <desugar-elements; concatenate-consecutive-strings; filter-breaks> elem* 
 
   desugar-template:
   	TemplateSquare(lines*) -> result
@@ -115,7 +115,7 @@ rules
         desugar-elements;
         map(line-remove-trailing-layout; line-ensure-leading-layout);
         unindent;
-        map(Line(concatenate-consecutive-strings));
+        map(Line(concatenate-consecutive-strings; filter-breaks));
         ?line'*
       end 
 
@@ -187,6 +187,9 @@ rules
   
   desugar-brackets:
   	Angled(p) ->  p
+  	
+  filter-breaks =
+  	filter(not(?BreakAngled() + ?BreakSquared()))
   	
 rules
 

--- a/org.metaborg.meta.lang.template/trans/analysis/desugar.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/desugar.str
@@ -75,9 +75,13 @@ rules
     where
       not(!line* => [_])
    with
-      let line-is-empty =
-            ?Line([]) + ?Line([Layout(_)])
-
+      let   
+          element-is-empty =
+            ?Layout(_) + ?BreakAngled() + ?BreakSquared()
+          
+          line-is-empty =
+            ?Line([]) + Line(all(element-is-empty))
+          
           remove-head-if-empty =
             try(\[<line-is-empty> | t] -> t\)
 
@@ -85,7 +89,7 @@ rules
             try(at-last(\[<line-is-empty>] -> []\))
 
           line-remove-trailing-layout =
-            try(Line(at-last(\[Layout(_)] -> []\)))
+            try(Line(at-last(\[<element-is-empty>] -> []\)))
 
           line-ensure-leading-layout =
             ?Line([Layout(_) | _]) <+ Line(![Layout("") | <id>])


### PR DESCRIPTION
This pull request adds support for breaks in tokens that do not introduce layout in the template.

For example, this production:

    ArrayType.ArrayType = <<ID>[]>

Can parse `a[]` but not `a[ ]`. If we want to allow layout in between the brackets, we have to write:

    ArrayType.ArrayType = <<ID>[ ]>

Now it can parse both `a[]` and `a[ ]`, but pretty-printing will return `a[ ]`. If we don't want the space when pretty-printing, we can now insert a _non-layout token break_, written as `<>` (or equivalently `[]`):

    ArrayType.ArrayType = <<ID>[<>]>

This still parses both `a[]` and `a[ ]`, but the pretty-printer will return `a[]`.