### PR TITLE
Make isLexical of parsetable.ProductionReader consistent with sdf2table.ParseTableProduction

### DIFF
--- a/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/productions/Production.java
+++ b/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/productions/Production.java
@@ -21,8 +21,8 @@ public class Production implements IProduction {
     private final ProductionAttributes attributes;
     private final boolean isListConstructor;
 
-    public Production(int productionId, ISymbol lhs, ISymbol[] rhs, Boolean isStringLiteral, Boolean isNumberLiteral,
-        Boolean isLexicalRhs, Boolean isSkippableInParseForest, ProductionAttributes attributes) {
+    public Production(int productionId, ISymbol lhs, ISymbol[] rhs, boolean isStringLiteral, boolean isNumberLiteral,
+        boolean isLexicalRhs, boolean isSkippableInParseForest, ProductionAttributes attributes) {
         this.productionId = productionId;
         this.lhs = lhs;
         this.rhs = rhs;

--- a/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/productions/ProductionReader.java
+++ b/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/productions/ProductionReader.java
@@ -4,8 +4,8 @@ import static org.spoofax.terms.Term.*;
 
 import java.util.Iterator;
 
-import org.metaborg.parsetable.characterclasses.CharacterClassReader;
 import org.metaborg.parsetable.ParseTableReadException;
+import org.metaborg.parsetable.characterclasses.CharacterClassReader;
 import org.metaborg.parsetable.symbols.ConcreteSyntaxContext;
 import org.metaborg.parsetable.symbols.ISortSymbol;
 import org.metaborg.parsetable.symbols.ISymbol;
@@ -45,7 +45,7 @@ public class ProductionReader {
         boolean isLexicalRhs = getIsLexicalRhs(rhsTerm);
         boolean isLayout = lhs.concreteSyntaxContext() == ConcreteSyntaxContext.Layout;
         boolean isLiteral = lhs.concreteSyntaxContext() == ConcreteSyntaxContext.Literal;
-        boolean isLexical = lhs.concreteSyntaxContext() == ConcreteSyntaxContext.Lexical;
+        boolean isLexical = lhs.concreteSyntaxContext() == ConcreteSyntaxContext.Lexical || isLexicalRhs;
 
         boolean skippableLayout = isLayout && !getIsLayoutParent(lhsTerm, rhsTerm);
         boolean skippableLexical = !(lhs instanceof ISortSymbol) && (isLexical || (isLexicalRhs && !isLiteral));
@@ -68,15 +68,12 @@ public class ProductionReader {
 
     private boolean getIsLexicalRhs(IStrategoList rhs) {
         if(rhs.getSubtermCount() > 0) {
-            boolean lexRhs = true;
-
             for(IStrategoTerm rhsPart : rhs.getAllSubterms()) {
-                String rhsPartConstructor = ((IStrategoAppl) rhsPart).getConstructor().getName();
-
-                lexRhs &= "char-class".equals(rhsPartConstructor);
+                if(!"char-class".equals(((IStrategoAppl) rhsPart).getConstructor().getName())) {
+                    return false;
+                }
             }
-
-            return lexRhs;
+            return true;
         } else
             return false;
     }


### PR DESCRIPTION
This inconsistency also caused differences in which parse nodes would be skippable in the parser, because `isSkippable` depends on `isLexical`.