### PR TITLE
Mark everything that is not context-free as skippable in parse forest

### DIFF
--- a/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/productions/IProduction.java
+++ b/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/productions/IProduction.java
@@ -39,7 +39,9 @@ public interface IProduction {
 
     boolean isLexical();
 
-    boolean isSkippableInParseForest();
+    default boolean isSkippableInParseForest() {
+        return !isContextFree();
+    }
 
     boolean isList();
 

--- a/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/productions/Production.java
+++ b/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/productions/Production.java
@@ -17,18 +17,16 @@ public class Production implements IProduction {
     private final int productionId;
     private final boolean isStringLiteral;
     private final boolean isNumberLiteral;
-    private final boolean isSkippableInParseForest;
     private final ProductionAttributes attributes;
     private final boolean isListConstructor;
 
     public Production(int productionId, ISymbol lhs, ISymbol[] rhs, boolean isStringLiteral, boolean isNumberLiteral,
-        boolean isLexicalRhs, boolean isSkippableInParseForest, ProductionAttributes attributes) {
+        boolean isLexicalRhs, ProductionAttributes attributes) {
         this.productionId = productionId;
         this.lhs = lhs;
         this.rhs = rhs;
         this.isStringLiteral = isStringLiteral;
         this.isNumberLiteral = isNumberLiteral;
-        this.isSkippableInParseForest = isSkippableInParseForest;
         this.attributes = attributes;
         this.isListConstructor = IProduction.isListConstructor(attributes.constructor);
 
@@ -114,10 +112,6 @@ public class Production implements IProduction {
 
     @Override public boolean isLexical() {
         return concreteSyntaxContext == ConcreteSyntaxContext.Lexical;
-    }
-
-    @Override public boolean isSkippableInParseForest() {
-        return isSkippableInParseForest;
     }
 
     @Override public boolean isList() {

--- a/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/productions/ProductionReader.java
+++ b/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/productions/ProductionReader.java
@@ -6,8 +6,6 @@ import java.util.Iterator;
 
 import org.metaborg.parsetable.ParseTableReadException;
 import org.metaborg.parsetable.characterclasses.CharacterClassReader;
-import org.metaborg.parsetable.symbols.ConcreteSyntaxContext;
-import org.metaborg.parsetable.symbols.ISortSymbol;
 import org.metaborg.parsetable.symbols.ISymbol;
 import org.metaborg.parsetable.symbols.SymbolReader;
 import org.spoofax.interpreter.terms.IStrategoAppl;
@@ -41,29 +39,11 @@ public class ProductionReader {
 
         boolean isStringLiteral = getIsStringLiteral(rhsTerm);
         boolean isNumberLiteral = getIsNumberLiteral(rhsTerm);
-
         boolean isLexicalRhs = getIsLexicalRhs(rhsTerm);
-        boolean isLayout = lhs.concreteSyntaxContext() == ConcreteSyntaxContext.Layout;
-        boolean isLiteral = lhs.concreteSyntaxContext() == ConcreteSyntaxContext.Literal;
-        boolean isLexical = lhs.concreteSyntaxContext() == ConcreteSyntaxContext.Lexical || isLexicalRhs;
-
-        boolean skippableLayout = isLayout && !getIsLayoutParent(lhsTerm, rhsTerm);
-        boolean skippableLexical = !(lhs instanceof ISortSymbol) && (isLexical || (isLexicalRhs && !isLiteral));
-
-        boolean isSkippableInParseForest = skippableLayout || skippableLexical;
 
         ProductionAttributes attributes = readProductionAttributes(attributesTerm);
 
-        return new Production(productionId, lhs, rhs, isStringLiteral, isNumberLiteral, isLexicalRhs,
-            isSkippableInParseForest, attributes);
-    }
-
-    private boolean getIsLayoutParent(IStrategoTerm lhs, IStrategoTerm rhs) {
-        String descriptor = lhs.toString() + " -> " + rhs.toString();
-
-        return "cf".equals(((IStrategoAppl) lhs).getConstructor().getName())
-            && !"cf(layout) -> [cf(layout),cf(layout)]".equals(descriptor)
-            && !"cf(opt(layout)) -> []".equals(descriptor);
+        return new Production(productionId, lhs, rhs, isStringLiteral, isNumberLiteral, isLexicalRhs, attributes);
     }
 
     private boolean getIsLexicalRhs(IStrategoList rhs) {

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/parsetable/ParseTableProduction.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/parsetable/ParseTableProduction.java
@@ -27,7 +27,6 @@ public class ParseTableProduction implements org.metaborg.parsetable.productions
     private final boolean isLayout;
     private final boolean isLiteral;
     private final boolean isLexical;
-    private final boolean isSkippableInParseForest;
     private final boolean isList;
     private final boolean isOptional;
     private final boolean isStringLiteral;
@@ -145,12 +144,6 @@ public class ParseTableProduction implements org.metaborg.parsetable.productions
 
         this.isContextFree = !(isLayout || isLiteral || isLexical || isLexicalRhs);
 
-        boolean isLayoutParent = getIsLayoutParent();
-        boolean skippableLayout = isLayout && !isLayoutParent;
-        boolean skippableLexical = sort == null && (isLexical || (isLexicalRhs && !isLiteral));
-
-        isSkippableInParseForest = skippableLayout || skippableLexical;
-
 
         ISymbol symb2 = p.leftHand();
         // not considering varsym
@@ -213,11 +206,6 @@ public class ParseTableProduction implements org.metaborg.parsetable.productions
             isLayout = true;
         }
         return isLayout;
-    }
-
-    private boolean getIsLayoutParent() {
-        return getIsLayout() && (getProduction().leftHand() instanceof ContextFreeSymbol)
-            && !this.toString().equals("LAYOUT-CF = LAYOUT-CF LAYOUT-CF") && !this.toString().equals("LAYOUT?-CF = ");
     }
 
     private boolean checkNotIsLetter(ISymbol s) {
@@ -284,11 +272,9 @@ public class ParseTableProduction implements org.metaborg.parsetable.productions
             return containsOptSymbol(((ContextFreeSymbol) s).getSymbol());
         } else if(s instanceof LexicalSymbol) {
             return containsOptSymbol(((LexicalSymbol) s).getSymbol());
+        } else {
+            return s instanceof OptionalSymbol;
         }
-        if(s instanceof OptionalSymbol) {
-            return true;
-        }
-        return false;
     }
 
     private boolean isIterSymbol(ISymbol s) {
@@ -427,10 +413,6 @@ public class ParseTableProduction implements org.metaborg.parsetable.productions
             }
         }
         return null;
-    }
-
-    @Override public boolean isSkippableInParseForest() {
-        return isSkippableInParseForest;
     }
 
     @Override public boolean isLongestMatch() {


### PR DESCRIPTION
Note that we could also remove the method `isSkippableInParseForest()` entirely, but it makes more sense to use this method in the `Reducer`s where parse forests are skipped :slightly_smiling_face: 