### PR TITLE
Return multiple files from builder, instead of writing files directly

### DIFF
--- a/org.metaborg.meta.lang.template/metaborg.yaml
+++ b/org.metaborg.meta.lang.template/metaborg.yaml
@@ -25,9 +25,17 @@ generates:
   directory: src-gen
 exports:
 - language: Stratego-Sugar
-  directory: src-gen  
+  directory: trans
+  includes:
+  - "**/*.str"
+- language: Stratego-Sugar
+  directory: src-gen
+  includes:
+  - "**/*.str"
 - language: ATerm
   directory: src-gen/statix
+  includes:
+  - "**/*.stx"
 pardonedLanguages:
 - EditorService
 - Stratego-Sugar

--- a/org.metaborg.meta.lang.template/trans/editor/build-all.str
+++ b/org.metaborg.meta.lang.template/trans/editor/build-all.str
@@ -43,79 +43,105 @@ rules
 
 // On-save handler
   generate-all:
-    (selected, position, ast, path, project-path) -> None()
+    (selected, position, ast, path, project-path) -> result
     where
       filename := <base-filename> path;
       ast'     := <desugar-templates> ast;
       <?Module(Unparameterized(mn), i*, sections)> ast
     where
-      esv-cc-filename         := <create-src-gen(|project-path, "completion/colorer" ,"-cc-esv.esv")> mn;
-      esv-cc-ast              := <module-to-cmp-colorer; pp-esv-to-string <+ !""; debug(!"ESV files could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> ast';
-      <write-string-to-file> (esv-cc-filename, esv-cc-ast)   
+      esv-cc-filename      := <get-src-gen(|project-path, "completion/colorer" ,"-cc-esv.esv")> mn;
+      esv-cc-ast           := <module-to-cmp-colorer; pp-esv-to-string <+ !""; debug(!"ESV files could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> ast';
+      esv-result           := (esv-cc-filename, esv-cc-ast)   
     where
       ncp-ast              := <module-to-new-cmp; pp-stratego-string <+ !""; debug(!"New Completions files could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> ast';
-      ncp-filename         := <create-src-gen(|project-path, "completion", "-cp.str")> mn;
-      <write-string-to-file> (ncp-filename, ncp-ast)             
+      ncp-filename         := <get-src-gen(|project-path, "completion", "-cp.str")> mn;
+      ncp-result           := (ncp-filename, ncp-ast)             
     where
       sig-ast              := <module-to-sig; pp-stratego-string <+ !""; debug(!"Signature files could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> ast';
-      sig-filename         := <create-src-gen(|project-path, "signatures", "-sig.str")> mn;
-      <write-string-to-file> (sig-filename, sig-ast)
+      sig-filename         := <get-src-gen(|project-path, "signatures", "-sig.str")> mn;
+      sig-result           := (sig-filename, sig-ast)
     where
       ds-sig-ast           := <module-to-ds-sig; pp-ds-to-string  <+ !""; debug(!"The ds signature file could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> ast';
-      ds-sig-filename      := <create-src-gen(|project-path, "ds-signatures", "-sig.ds")> mn;
-      <write-string-to-file> (ds-sig-filename, ds-sig-ast)
+      ds-sig-filename      := <get-src-gen(|project-path, "ds-signatures", "-sig.ds")> mn;
+      ds-sig-result        :=  (ds-sig-filename, ds-sig-ast)
     where
     version             := <check-sdf2table>;
       if <?"disabled" <+ ?"mixin-grammar"> version then
         // regular table     
-        norm-filename       := <create-src-gen(|project-path, "syntax/normalized",  "-norm.aterm")> mn;
+        norm-filename       := <get-src-gen(|project-path, "syntax/normalized",  "-norm.aterm")> mn;
         norm-ast            := <module-to-permissive; to-normal-form(|$[[project-path]/[<dirname> path]])> ast';
-        <write-string-to-file> (norm-filename, <aterm-escape-strings; pp-aterm> norm-ast);
+        norm-result         := (norm-filename, <aterm-escape-strings; pp-aterm> norm-ast);
         
         // completions table 
-        sdf-completions-filename         := <create-src-gen(|project-path, "syntax/normalized/completion", "-completion-insertions-norm.aterm")> mn;
+        sdf-completions-filename         := <get-src-gen(|project-path, "syntax/normalized/completion", "-completion-insertions-norm.aterm")> mn;
         sdf-completions-ast              := <module-to-sdf3-completions; to-normal-form(|$[[project-path]/[<dirname> path]]) <+ !""; debug(!"SDF completion files could not be generated.\n"); fail > ast';
-        <write-string-to-file> (sdf-completions-filename, <aterm-escape-strings; pp-aterm> sdf-completions-ast);  
+        sdf-completions-result           := (sdf-completions-filename, <aterm-escape-strings; pp-aterm> sdf-completions-ast);  
         
         chars                := <collect-one(?Tokenize(<id; explode-string; un-double-quote-chars>)) <+ !['(', ')']> sections;
         newline              := <collect-one(?Newlines(<id>)) <+ !None()> sections;
         kfr                  := <collect-one(?KeywordFollowRestriction(<id; term-translation>)) <+ !None()> sections;
         kattrs               := <collect-one(?KeywordAttributes(_, _)) <+ !None()> sections;
-        sdf-filename         := <create-src-gen(|project-path, "syntax", ".sdf")> mn;
+        sdf-filename         := <get-src-gen(|project-path, "syntax", ".sdf")> mn;
         sdf-ast              := <to-sdf(|chars, newline, kfr, kattrs); pp-sdf-to-string <+ !""; debug(!"SDF files could not be generated.\n"); fail > ast';
-        <write-string-to-file> (sdf-filename, sdf-ast);
+        sdf-result           := (sdf-filename, sdf-ast);
           
         // to completions table from sdf2table
-        sdf-completions-sdf2table-filename         := <create-src-gen(|project-path, "syntax/completion", "-completion-insertions.sdf")> mn;
+        sdf-completions-sdf2table-filename         := <get-src-gen(|project-path, "syntax/completion", "-completion-insertions.sdf")> mn;
         sdf-completions-sdf2table-ast              := <module-to-sdf-completions; pp-sdf-to-string  <+ !""; debug(!"SDF completion files could not be generated.\n"); fail > ast';
-        <write-string-to-file> (sdf-completions-sdf2table-filename, sdf-completions-sdf2table-ast)
+        sdf-completions-sdf2table-result           := (sdf-completions-sdf2table-filename, sdf-completions-sdf2table-ast);
+        
+        sdf2table-result* := [
+          norm-result,
+          sdf-completions-result,
+          sdf-result,
+          sdf-completions-sdf2table-result
+        ]
       else if <?"java" <+ ?"dynamic" <+ ?"incremental"> version then
           // regular table     
-          norm-filename       := <create-src-gen(|project-path, "syntax/normalized",  "-norm.aterm")> mn;
+          norm-filename       := <get-src-gen(|project-path, "syntax/normalized",  "-norm.aterm")> mn;
           norm-ast            := <module-to-permissive; to-normal-form(|$[[project-path]/[<dirname> path]])> ast';
-          <write-string-to-file> (norm-filename, <aterm-escape-strings; pp-aterm> norm-ast);
+          norm-result         := (norm-filename, <aterm-escape-strings; pp-aterm> norm-ast);
           
           // completions table 
-          sdf-completions-filename         := <create-src-gen(|project-path, "syntax/normalized/completion", "-completion-insertions-norm.aterm")> mn;
+          sdf-completions-filename         := <get-src-gen(|project-path, "syntax/normalized/completion", "-completion-insertions-norm.aterm")> mn;
           sdf-completions-ast              := <module-to-sdf3-completions; to-normal-form(|$[[project-path]/[<dirname> path]]) <+ !""; debug(!"SDF completion files could not be generated.\n"); fail > ast';
-          <write-string-to-file> (sdf-completions-filename, <aterm-escape-strings; pp-aterm> sdf-completions-ast)  
+          sdf-completions-result           := (sdf-completions-filename, <aterm-escape-strings; pp-aterm> sdf-completions-ast)  ;
+          
+          sdf2table-result* := [
+            norm-result,
+            sdf-completions-result
+          ]
         else
           	chars                := <collect-one(?Tokenize(<id; explode-string; un-double-quote-chars>)) <+ !['(', ')']> sections;
         		newline              := <collect-one(?Newlines(<id>)) <+ !None()> sections;
           	kfr                  := <collect-one(?KeywordFollowRestriction(<id; term-translation>)) <+ !None()> sections;
           	kattrs               := <collect-one(?KeywordAttributes(_, _)) <+ !None()> sections;
-          	sdf-filename         := <create-src-gen(|project-path, "syntax", ".sdf")> mn;
+          	sdf-filename         := <get-src-gen(|project-path, "syntax", ".sdf")> mn;
           	sdf-ast              := <to-sdf(|chars, newline, kfr, kattrs); pp-sdf-to-string <+ !""; debug(!"SDF files could not be generated.\n"); fail > ast';
-          	<write-string-to-file> (sdf-filename, sdf-ast);
+          	sdf-result           := (sdf-filename, sdf-ast);
   	      
           // to completions table from sdf2table
-          sdf-completions-filename         := <create-src-gen(|project-path, "syntax/completion", "-completion-insertions.sdf")> mn;
+          sdf-completions-filename         := <get-src-gen(|project-path, "syntax/completion", "-completion-insertions.sdf")> mn;
           sdf-completions-ast              := <module-to-sdf-completions; pp-sdf-to-string  <+ !""; debug(!"SDF completion files could not be generated.\n"); fail > ast';
-          <write-string-to-file> (sdf-completions-filename, sdf-completions-ast)
+          sdf-completions-result           := (sdf-completions-filename, sdf-completions-ast);
+
+          sdf2table-result* := [
+            sdf-result,
+            sdf-completions-result
+          ]
         end  
       end
     where
         pp-ast               := <module-to-pp; pp-stratego-string <+ !""; debug(!"PP files could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> ast'
-      ; pp-filename          := <create-src-gen(|project-path, "pp", "-pp.str")> mn;
-        <write-string-to-file> (pp-filename, pp-ast)  
+      ; pp-filename          := <get-src-gen(|project-path, "pp", "-pp.str")> mn;
+        pp-result            := (pp-filename, pp-ast)  
+    where
+        result := <unzip> [
+          esv-result,
+          ncp-result,
+          sig-result,
+          ds-sig-result,
+          sdf2table-result*,
+          pp-result
+        ]
      

--- a/org.metaborg.meta.lang.template/trans/editor/build-all.str
+++ b/org.metaborg.meta.lang.template/trans/editor/build-all.str
@@ -50,20 +50,20 @@ rules
       <?Module(Unparameterized(mn), i*, sections)> ast
     where
       esv-cc-filename      := <get-src-gen(|project-path, "completion/colorer" ,"-cc-esv.esv")> mn;
-      esv-cc-ast           := <module-to-cmp-colorer; pp-esv-to-string <+ !""; debug(!"ESV files could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> ast';
-      esv-result           := (esv-cc-filename, esv-cc-ast)   
+      esv-cc-string        := <module-to-cmp-colorer; pp-esv-to-string <+ !""; debug(!"ESV files could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> ast';
+      esv-result           := (esv-cc-filename, esv-cc-string)   
     where
-      ncp-ast              := <module-to-new-cmp; pp-stratego-string <+ !""; debug(!"New Completions files could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> ast';
+      ncp-string           := <module-to-new-cmp; pp-stratego-string <+ !""; debug(!"New Completions files could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> ast';
       ncp-filename         := <get-src-gen(|project-path, "completion", "-cp.str")> mn;
-      ncp-result           := (ncp-filename, ncp-ast)             
+      ncp-result           := (ncp-filename, ncp-string)             
     where
-      sig-ast              := <module-to-sig; pp-stratego-string <+ !""; debug(!"Signature files could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> ast';
+      sig-string           := <module-to-sig; pp-stratego-string <+ !""; debug(!"Signature files could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> ast';
       sig-filename         := <get-src-gen(|project-path, "signatures", "-sig.str")> mn;
-      sig-result           := (sig-filename, sig-ast)
+      sig-result           := (sig-filename, sig-string)
     where
-      ds-sig-ast           := <module-to-ds-sig; pp-ds-to-string  <+ !""; debug(!"The ds signature file could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> ast';
+      ds-sig-string        := <module-to-ds-sig; pp-ds-to-string  <+ !""; debug(!"The ds signature file could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> ast';
       ds-sig-filename      := <get-src-gen(|project-path, "ds-signatures", "-sig.ds")> mn;
-      ds-sig-result        :=  (ds-sig-filename, ds-sig-ast)
+      ds-sig-result        :=  (ds-sig-filename, ds-sig-string)
     where
     version             := <check-sdf2table>;
       if <?"disabled" <+ ?"mixin-grammar"> version then
@@ -132,9 +132,9 @@ rules
         end  
       end
     where
-        pp-ast               := <module-to-pp; pp-stratego-string <+ !""; debug(!"PP files could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> ast'
+        pp-string            := <module-to-pp; pp-stratego-string <+ !""; debug(!"PP files could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> ast'
       ; pp-filename          := <get-src-gen(|project-path, "pp", "-pp.str")> mn;
-        pp-result            := (pp-filename, pp-ast)  
+        pp-result            := (pp-filename, pp-string)  
     where
         result := <unzip> [
           esv-result,

--- a/org.metaborg.meta.lang.template/trans/editor/build-completions.str
+++ b/org.metaborg.meta.lang.template/trans/editor/build-completions.str
@@ -16,7 +16,7 @@ rules
      where
         <?Module(Unparameterized(mn), i*, sections)> ast ;
         ast'     := <desugar-templates> selected;
-        filename := <create-src-gen(|project-path, "completion/colorer" ,"-cc-esv.esv")> mn;
+        filename := <get-src-gen(|project-path, "completion/colorer" ,"-cc-esv.esv")> mn;
         result   := <module-to-cmp-colorer; pp-esv-to-string <+ !""; debug(!"ESV files could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> ast'
         
   generate-new-completions-stratego:
@@ -25,4 +25,4 @@ rules
         <?Module(Unparameterized(mn), i*, sections)> ast ;
         ast'     := <desugar-templates> selected;
         result   := <module-to-new-cmp; pp-stratego-string <+ !""; debug(!"New Completions files could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> ast';
-        filename := <create-src-gen(|project-path, "completion", "-cp.str")> mn
+        filename := <get-src-gen(|project-path, "completion", "-cp.str")> mn

--- a/org.metaborg.meta.lang.template/trans/editor/build-deprecated.str
+++ b/org.metaborg.meta.lang.template/trans/editor/build-deprecated.str
@@ -22,7 +22,7 @@ rules
       selected'     := <desugar-templates> selected;
       result   := <module-to-chk; pp-stratego-string <+ !""; debug(!"The check file could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> selected'
       //; fn       :=  <get-filename> mn
-      ; filename := <create-src-gen(|project-path, "check", "-chk.str")> mn
+      ; filename := <get-src-gen(|project-path, "check", "-chk.str")> mn
 
    generate-ast-checker-abstract:
     (selected, position, ast, path, project-path) -> (filename, result)
@@ -35,7 +35,7 @@ rules
       selected'     := <desugar-templates> selected;
       result   := <module-to-chk> selected'
       //; fn       :=  <get-filename> mn
-      ; filename := <create-src-gen(|project-path, "check", "-chk.aterm")> mn
+      ; filename := <get-src-gen(|project-path, "check", "-chk.aterm")> mn
 
 
   generate-esv-abstract:
@@ -44,7 +44,7 @@ rules
       <?Module(Unparameterized(mn), i*, _)> ast ;
       selected'     := <desugar-templates> selected;
       result   :=  <module-to-esv; topdown(try(pp-fix-string-quotes))> selected'
-      ; filename := <create-src-gen(|project-path, "completions", ".esv.aterm")> mn
+      ; filename := <get-src-gen(|project-path, "completions", ".esv.aterm")> mn
 
    generate-esv-concrete:
     (selected, position, ast, path, project-path) -> (filename, result)
@@ -56,4 +56,4 @@ rules
       <?Module(Unparameterized(mn), i*, sections)> ast ;
       selected'     := <desugar-templates> selected;
       result   := <module-to-esv; pp-esv-to-string <+ !""; debug(!"The esv file could not be generated. Try Reset and Reanalyze or check for unresolved references.\n")> selected'
-      ; filename := <create-src-gen(|project-path, "completions" ,"-esv.esv")> mn
+      ; filename := <get-src-gen(|project-path, "completions" ,"-esv.esv")> mn

--- a/org.metaborg.meta.lang.template/trans/editor/build-format.str
+++ b/org.metaborg.meta.lang.template/trans/editor/build-format.str
@@ -18,35 +18,35 @@ rules
     with
       <?Module(Unparameterized(mn), i*, sections)> ast ;
       result   := <bottomup(try(sugar-attributes); try(sugar-priorities))> ast;
-      filename := <create-src-gen(|project-path, "formatted", ".aterm")> mn
+      filename := <get-src-gen(|project-path, "formatted", ".aterm")> mn
   
   pp-sdf3:
     (selected, position, ast, path, project-path) -> (filename, result)
     with
       <?Module(Unparameterized(mn), i*, sections)> ast ;
       result   := <pp-SDF3-string> ast;
-      filename := <create-src-gen(|project-path, "formatted", ".sdf3")> mn
+      filename := <get-src-gen(|project-path, "formatted", ".sdf3")> mn
 
   lift-sdf3:
     (selected, position, ast, path, project-path) -> (filename, result)
     with
       <?Module(Unparameterized(mn), i*, sections)> ast ;
       result   := <bottomup(try(sugar-attributes); try(sugar-priorities)); pp-SDF3-string> ast;
-      filename := <create-src-gen(|project-path, "formatted", ".sdf3")> mn
+      filename := <get-src-gen(|project-path, "formatted", ".sdf3")> mn
         
   lift-sdf3-template-abstract:
     (selected, position, ast, path, project-path) -> (filename, result)
     with
       <?Module(Unparameterized(mn), i*, sections)> ast ;
       result   := <module-to-template> ast;
-      filename := <create-src-gen(|project-path, "formatted", ".aterm")> mn
+      filename := <get-src-gen(|project-path, "formatted", ".aterm")> mn
 
    lift-sdf3-template:
     (selected, position, ast, path, project-path) -> (filename, result)
     with
       <?Module(Unparameterized(mn), i*, sections)> ast ;
       result   := < module-to-template;bottomup(try(sugar-attributes);try(sugar-priorities)); pp-SDF3-string> ast;
-      filename := <create-src-gen(|project-path, "formatted", ".sdf3")> mn    
+      filename := <get-src-gen(|project-path, "formatted", ".sdf3")> mn    
       
   extract-regular-productions:    
     (selected, position, ast, path, project-path) -> (filename, result)
@@ -54,7 +54,7 @@ rules
       <?Module(Unparameterized(mn), i*, sections)> ast ;
       chars := <collect-one(?Tokenize(<id; explode-string; un-double-quote-chars>)) <+ !['(', ')']> sections;
       result   := <desugar-templates; remove-templates(|chars); bottomup(try(sugar-attributes); try(sugar-priorities)); pp-SDF3-string> ast;
-      filename := <create-src-gen(|project-path, "formatted", ".sdf3")> mn    
+      filename := <get-src-gen(|project-path, "formatted", ".sdf3")> mn    
     
   extract-regular-productions-abstract:   
     (selected, position, ast, path, project-path) -> (filename, result)
@@ -62,5 +62,5 @@ rules
       <?Module(Unparameterized(mn), i*, sections)> ast ;
       chars := <collect-one(?Tokenize(<id; explode-string; un-double-quote-chars>)) <+ !['(', ')']> sections;
       result   := <desugar-templates; remove-templates(|chars); bottomup(try(sugar-attributes); try(sugar-priorities))> ast;
-      filename := <create-src-gen(|project-path, "formatted", ".aterm")> mn   
+      filename := <get-src-gen(|project-path, "formatted", ".aterm")> mn   
 

--- a/org.metaborg.meta.lang.template/trans/editor/build-pp.str
+++ b/org.metaborg.meta.lang.template/trans/editor/build-pp.str
@@ -17,7 +17,7 @@ rules
       selected'     := <desugar-templates> selected;
       result   :=  <module-to-pp> selected'
      // ; fn       :=  <get-filename> mn
-      ; filename := <create-src-gen(|project-path, "pp", ".pp.aterm")> mn//fn
+      ; filename := <get-src-gen(|project-path, "pp", ".pp.aterm")> mn//fn
 
   generate-pp-concrete:
 
@@ -30,5 +30,5 @@ rules
       <?Module(Unparameterized(mn), i*, _)> ast ;
       selected'     := <desugar-templates> selected;
       result   := <module-to-pp; pp-stratego-string <+ !""; debug(!"The pp file could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> selected'
-      ; filename := <create-src-gen(|project-path, "pp", "-pp.str"); debug(!"filename ")> mn
+      ; filename := <get-src-gen(|project-path, "pp", "-pp.str"); debug(!"filename ")> mn
 

--- a/org.metaborg.meta.lang.template/trans/editor/build-sdf-completions.str
+++ b/org.metaborg.meta.lang.template/trans/editor/build-sdf-completions.str
@@ -40,5 +40,5 @@ rules
    where
      <?Module(Unparameterized(mn), i*, sections)> ast ;
      selected' := <desugar-templates> selected;
-     filename  := <create-src-gen(|project-path, "syntax/completion", "-completion-insertions.sdf3")> mn;
+     filename  := <get-src-gen(|project-path, "syntax/completion", "-completion-insertions.sdf3")> mn;
      result    := <module-to-sdf3-completions; pp-SDF3-string <+ !""; debug(!"The sdf3 file could not be generated.\n"); fail> selected'

--- a/org.metaborg.meta.lang.template/trans/editor/build-sig.str
+++ b/org.metaborg.meta.lang.template/trans/editor/build-sig.str
@@ -17,7 +17,7 @@ rules
       selected'     := <desugar-templates> selected;
 
       result   := <module-to-sig> selected'
-      ; filename := <create-src-gen(|project-path, "signatures", ".sig.aterm")> mn
+      ; filename := <get-src-gen(|project-path, "signatures", ".sig.aterm")> mn
 
   generate-sig-concrete:
     (selected, position, ast, path, project-path) -> (filename, result)
@@ -29,7 +29,7 @@ rules
       <?Module(Unparameterized(mn), i*, _)> ast ;
       selected'     := <desugar-templates> selected;
       result   := <module-to-sig; pp-stratego-string <+ !""; debug(!"The signature file could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> selected'
-      ; filename := <create-src-gen(|project-path, "signatures", "-sig.str")> mn
+      ; filename := <get-src-gen(|project-path, "signatures", "-sig.str")> mn
 
   generate-dynsem:
     (selected, position, ast, path, project-path) -> (filename, result)
@@ -41,7 +41,7 @@ rules
       <?Module(Unparameterized(mn), i*, _)> ast ;
       selected'     := <desugar-templates> selected;
       result   := <module-to-ds-sig; pp-ds-to-string  <+ !""; debug(!"The signature file could not be generated. Try Reset and Reanalyze or check for unresolved references.\n"); fail> selected'
-      ; filename := <create-src-gen(|project-path, "ds-signatures", "-sig.ds")> mn
+      ; filename := <get-src-gen(|project-path, "ds-signatures", "-sig.ds")> mn
 
   generate-dynsem-abstract:
     (selected, position, ast, path, project-path) -> (filename, result)
@@ -53,5 +53,5 @@ rules
       <?Module(Unparameterized(mn), i*, _)> ast ;
       selected'     := <desugar-templates> selected;
       result   := <module-to-ds-sig> selected';
-      filename := <create-src-gen(|project-path, "ds-signatures/ds", "-dssig.aterm")> mn
+      filename := <get-src-gen(|project-path, "ds-signatures/ds", "-dssig.aterm")> mn
    

--- a/org.metaborg.meta.lang.template/trans/editor/build-syntax.str
+++ b/org.metaborg.meta.lang.template/trans/editor/build-syntax.str
@@ -32,7 +32,7 @@ rules
       kattrs:= <collect-one(?KeywordAttributes(_, _)) <+ !None()> sections;
       selected'     := <desugar-templates> selected;
       //selected' := selected ;
-      filename := <create-src-gen(|project-path, "syntax",  ".sdf.aterm")> mn;
+      filename := <get-src-gen(|project-path, "syntax",  ".sdf.aterm")> mn;
       result := <to-sdf(|chars, newline, kfr, kattrs)> selected'
 
   generate-sdf-concrete:
@@ -48,14 +48,14 @@ rules
       kfr := <collect-one(?KeywordFollowRestriction(<id; term-translation>)) <+ !None()> sections;
       kattrs:= <collect-one(?KeywordAttributes(_, _)) <+ !None()> sections;
       selected'     := <desugar-templates> selected;
-      filename := <create-src-gen(|project-path, "syntax", ".sdf")> mn;
+      filename := <get-src-gen(|project-path, "syntax", ".sdf")> mn;
       result   := <to-sdf(|chars, newline, kfr, kattrs); pp-sdf-to-string <+ !""; debug(!"The sdf file could not be generated.\n"); fail> selected'
   
    generate-permissive-abstract:
     (selected, position, ast, path, project-path) -> (filename, result)
     where
         <?Module(Unparameterized(mn), i*, sections)> ast ;
-        filename := <create-src-gen(|project-path, "syntax/permissive" ,"-permissive.aterm")> mn;
+        filename := <get-src-gen(|project-path, "syntax/permissive" ,"-permissive.aterm")> mn;
         ast'     := <desugar-templates> selected;
         result := <module-to-permissive-productions> ast'
   
@@ -63,53 +63,59 @@ rules
     (selected, position, ast, path, project-path) -> (filename, result)
     where
         <?Module(Unparameterized(mn), i*, sections)> ast ;
-        filename := <create-src-gen(|project-path, "syntax/permissive" ,"-permissive.sdf3")> mn;
+        filename := <get-src-gen(|project-path, "syntax/permissive" ,"-permissive.sdf3")> mn;
         ast'     := <desugar-templates> selected;
         result   := <module-to-permissive-productions; pp-SDF3-string> ast'    
         
   sdf3-to-namespaced:
-    (selected, position, ast, path, project-path) -> None()
+    (selected, position, ast, path, project-path) -> norm-namespaced-result
     where 
       <?Module(Unparameterized(mn), i*, sections)> ast ;
       dirname := <dirname> path;
       if <not(is-substring(!"namespaced"))> dirname then
 	      norm-namespaced-filename       := <concat-strings> [project-path, "/syntax/namespaced/", mn, "-namespaced.sdf3"];
 	      norm-namespaced-ast            := <module-to-namespaced> ast;
-	      <write-string-to-file> (norm-namespaced-filename, <pp-SDF3-string> norm-namespaced-ast)
+	      norm-namespaced-result         := (norm-namespaced-filename, <pp-SDF3-string> norm-namespaced-ast)
+	    else
+	      result := None()
       end 
       
   sdf3-to-exp-grammars:
-    (selected, position, ast, path, project-path) -> None()
+    (selected, position, ast, path, project-path) -> result
     where 
-      exp-grammars := <module-to-exp-grammars(|project-path, path)> ast;
-      <map(generate-exp-grammar-file(|project-path))> exp-grammars;
-      <map(generate-exp-grammar-str-file(|project-path))> exp-grammars
+      exp-grammars            := <module-to-exp-grammars(|project-path, path)> ast;
+      exp-grammar-result*     := <map(generate-exp-grammar-file(|project-path))> exp-grammars;
+      exp-grammar-str-result* := <map(generate-exp-grammar-str-file(|project-path))> exp-grammars;
+      result := <unzip> [
+        exp-grammar-result*,
+        exp-grammar-str-result*
+      ]
   
   generate-exp-grammar-file(|project-path):
-    (mn, ast) -> None()
+    (mn, ast) -> exp-grammar-result
     where
-      exp-grammar-filename := <create-src-gen(|project-path, "syntax/exp-grammars",  ".sdf3_")> mn;
-      <write-string-to-file> (exp-grammar-filename, <pp-SDF3-string> ast)
+      exp-grammar-filename := <get-src-gen(|project-path, "syntax/exp-grammars",  ".sdf3_")> mn;
+      exp-grammar-result   := (exp-grammar-filename, <pp-SDF3-string> ast)
       
   generate-exp-grammar-str-file(|project-path):
-    (mn, ast) -> None()
+    (mn, ast) -> stratego-result
     where
-      exp-grammar-filename := <create-src-gen(|project-path, "syntax/exp-grammars",  ".str")> mn;
+      exp-grammar-filename := <get-src-gen(|project-path, "syntax/exp-grammars",  ".str")> mn;
       stratego-ast         := <module-to-str-expr-grammar> ast;
-      <write-string-to-file> (exp-grammar-filename, <pp-stratego-string> stratego-ast)    
+      stratego-result      := (exp-grammar-filename, <pp-stratego-string> stratego-ast)    
          
   sdf3-to-normal-form:
     (selected, position, ast, path, project-path) -> (filename, result)
     with
     <?Module(Unparameterized(mn), i*, sections)> ast ;
-    filename := <create-src-gen(|project-path, "syntax/normalized",  "-norm.sdf3_")> mn;
+    filename := <get-src-gen(|project-path, "syntax/normalized",  "-norm.sdf3_")> mn;
     result   := <to-normal-form(|$[[project-path]/[<dirname> path]]); pp-SDF3-string> selected  
     
   sdf3-to-normal-form-abstract:
     (selected, position, ast, path, project-path) -> (filename, result)
     with
     <?Module(Unparameterized(mn), i*, sections)> ast ;
-    filename := <create-src-gen(|project-path, "syntax/normalized",  "-norm.aterm")> mn;
+    filename := <get-src-gen(|project-path, "syntax/normalized",  "-norm.aterm")> mn;
     result   := <to-normal-form(|$[[project-path]/[<dirname> path]])> selected      
          
   read-contextual-grammar-abstract:
@@ -117,6 +123,6 @@ rules
    where
    <debug(!"project-path ")> project-path;
    ctx-ast      := <get-contextual-grammar> project-path; 
-   filename     := <create-src-gen(|project-path, "syntax", ".sdf3_")> "contextualGrammar";
+   filename     := <get-src-gen(|project-path, "syntax", ".sdf3_")> "contextualGrammar";
    result       := <pp-SDF3-string> ctx-ast     
        

--- a/org.metaborg.meta.lang.template/trans/editor/build-utils.str
+++ b/org.metaborg.meta.lang.template/trans/editor/build-utils.str
@@ -52,55 +52,29 @@ rules
     tbl := <import-term(target/metaborg/EditorService-pretty.pp.af)>;
     rules(DescriptorPPTable := tbl)
     
-    // When given a tuple (path, string) this writes string into path.
-    write-string-to-file =
-        ?(filename, string);
-        if <dirname; readdir> filename then
-          with(
-            handle := <fopen> (filename, "w");
-            <fputs> (string, handle);
-            <fclose> handle
-          )
-        end
-    
-    create-src-gen(|project-path, folder, ext):
-        filename -> filename'
-        with
-            fn := <get-filename> filename; 
-            src-gen-path := <concat-strings; create-dir> [project-path, "/src-gen"];
-            src-gen-folder := <concat-strings; create-dir> [src-gen-path, "/" ,folder];
-            file-folder := <get-dir(|src-gen-folder)> filename ;
-            filename' := <concat-strings> [file-folder, "/" , fn, ext]
-  
-    get-dir(|path) :
+  get-src-gen(|project-path, folder, ext):
+    filename -> filename'
+    with
+        fn := <get-filename> filename; 
+        src-gen-path := <concat-strings> [project-path, "/src-gen"];
+        src-gen-folder := <concat-strings> [src-gen-path, "/" ,folder];
+        file-folder := <get-dir(|src-gen-folder)> filename ;
+        filename' := <concat-strings> [file-folder, "/" , fn, ext]
+
+
+  get-dir(|path) :
     s -> s'
     with
       names := <strip-annos; string-tokenize(|['/'])> s;
       names' := <at-last(![])> names;
       if [h | tl] := names'
-      then      
-        first := <concat-strings> [path, "/" ,h]; 
-                <create-dirs(|first)> tl;
-                s' := <concat-strings> [path, "/",  <separate-by(|"/"); concat-strings> names']
-        else
-          s' := path
-        end
+      then
+        s' := <concat-strings> [path, "/",  <separate-by(|"/"); concat-strings> names']
+      else
+        s' := path
+      end
 
 
-   create-dir  = not( file-exists ; filemode ; isdir) < mkdir + id
-
-   create-dirs(|dir):
-    [h | tl] -> None()
-    where
-      <create-dir> dir;
-      new-dir := <concat-strings> [dir, "/", h];
-      <create-dirs(|new-dir)> tl
-
-    create-dirs(|dir):
-    [] -> None()
-    where
-      <create-dir> dir
-  
   get-filename :
     s -> s'
     with

--- a/org.metaborg.meta.lang.template/trans/templatelang.str
+++ b/org.metaborg.meta.lang.template/trans/templatelang.str
@@ -107,16 +107,3 @@ rules // Debugging
 
   // analysis-default-debug-interface(msg) = debug(msg)
   // analysis-default-debug-interface = debug
-
-rules
-
-  // When given a tuple (path, string) this writes string into path.
-  write-string-to-file =
-    ?(filename, string);
-    if <dirname; readdir> filename then
-      with(
-        handle := <fopen> (filename, "w");
-        <fputs> (string, handle);
-        <fclose> handle
-      )
-    end


### PR DESCRIPTION
Use the proper API for returning multiple files from the builder in SDF. This also improves the interaction with Statix and other languages that analyze generated files.