### PR TITLE
Consistent topDownHasSpaces between Java and ATerm parse table

### DIFF
--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/parsetable/ParseTableProduction.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/parsetable/ParseTableProduction.java
@@ -250,14 +250,24 @@ public class ParseTableProduction implements org.metaborg.parsetable.productions
     }
 
     private boolean topdownHasSpaces(List<ISymbol> rightHand) {
-        // This function has been copied from the JSGLR1 with the following comment:
+        // This function has been modified from the JSGLR1 with the following comment:
         // Return true if any character range of this contains spaces
+        return rightHand.stream().anyMatch(this::topdownHasSpaces);
+    }
 
-        for(ISymbol s : rightHand) {
-            if(s instanceof CharacterClassSymbol && ((CharacterClassSymbol) s).getCC().contains('0')) {
-                return true;
-            }
-        }
+    private boolean topdownHasSpaces(ISymbol s) {
+        if(s instanceof CharacterClassSymbol && ((CharacterClassSymbol) s).getCC().contains(' '))
+            return true;
+        if(s instanceof LexicalSymbol)
+            return topdownHasSpaces(((LexicalSymbol) s).getSymbol());
+        if(s instanceof IterStarSepSymbol)
+            return topdownHasSpaces(((IterStarSepSymbol) s).getSymbol());
+        if(s instanceof IterStarSymbol)
+            return topdownHasSpaces(((IterStarSymbol) s).getSymbol());
+        if(s instanceof IterSepSymbol)
+            return topdownHasSpaces(((IterSepSymbol) s).getSymbol());
+        if(s instanceof IterSymbol)
+            return topdownHasSpaces(((IterSymbol) s).getSymbol());
         return false;
     }
 


### PR DESCRIPTION
This makes `ParseTableProduction.topDownHasSpaces(List<ISymbol>)` consistent with [`org.metaborg.parsetable.productions.ProductionReader`](https://github.com/metaborg/sdf/blob/master/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/productions/ProductionReader.java#L61-L90).
The ProductionReader reads an ATerm symbol from the parse table literally top-down: wrappers like `lex(...)`, `iter-star(...)`, etc. are stripped from the underlying character class.
This change in `ParseTableProduction` mimics this behaviour by stripping off the wrapper `Symbol` classes.