### PR TITLE
Errors for non-assoc by storing extra data in parse table

### DIFF
--- a/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/IParseTableGenerator.java
+++ b/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/IParseTableGenerator.java
@@ -10,8 +10,9 @@ public interface IParseTableGenerator {
     IParseTable getParseTable();
 
     IStrategoTerm getStateAterm(IState s);
-    
-    SetMultimap<String, String> getNonAssocPriorities();
 
-    SetMultimap<String, String> getNonNestedPriorities();
+    SetMultimap<String, String> getNonAssocProductions();
+
+    SetMultimap<String, String> getNonNestedProductions();
+
 }

--- a/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/IParseTableGenerator.java
+++ b/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/IParseTableGenerator.java
@@ -3,16 +3,10 @@ package org.metaborg.parsetable;
 import org.metaborg.parsetable.states.IState;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 
-import com.google.common.collect.SetMultimap;
-
 public interface IParseTableGenerator {
 
     IParseTable getParseTable();
 
     IStrategoTerm getStateAterm(IState s);
-
-    SetMultimap<String, String> getNonAssocProductions();
-
-    SetMultimap<String, String> getNonNestedProductions();
 
 }

--- a/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/productions/IProduction.java
+++ b/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/productions/IProduction.java
@@ -64,4 +64,8 @@ public interface IProduction {
 
     boolean isBracket();
 
+    boolean isNonAssocWith(IProduction other);
+
+    boolean isNonNestedWith(IProduction other);
+
 }

--- a/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/productions/Production.java
+++ b/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/productions/Production.java
@@ -175,4 +175,12 @@ public class Production implements IProduction {
         return attributes.isBracket;
     }
 
+    @Override public boolean isNonAssocWith(IProduction other) {
+        return attributes.nonAssocWith != null && attributes.nonAssocWith.contains(other.id());
+    }
+
+    @Override public boolean isNonNestedWith(IProduction other) {
+        return attributes.nonNestedWith != null && attributes.nonNestedWith.contains(other.id());
+    }
+
 }

--- a/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/productions/ProductionAttributes.java
+++ b/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/productions/ProductionAttributes.java
@@ -1,5 +1,7 @@
 package org.metaborg.parsetable.productions;
 
+import java.util.Set;
+
 import org.spoofax.interpreter.terms.IStrategoNamed;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 
@@ -19,11 +21,13 @@ public class ProductionAttributes {
     public final boolean isCaseInsensitive;
     public final boolean isIndentPaddingLexical;
     public final boolean isFlatten;
+    public final Set<Integer> nonAssocWith;
+    public final Set<Integer> nonNestedWith;
 
     ProductionAttributes(ProductionType type, IStrategoTerm constructorTerm, boolean isRecovery, boolean isBracket,
         boolean isCompletion, boolean isPlaceholderInsertion, boolean isLiteralCompletion, boolean isIgnoreIndent,
         boolean isNewlineEnforced, boolean isLongestMatch, boolean isCaseInsensitive, boolean isIndentPaddingLexical,
-        boolean isFlatten) {
+        boolean isFlatten, Set<Integer> nonAssocWith, Set<Integer> nonNestedWith) {
         this.type = type;
         this.constructorTerm = constructorTerm;
         this.constructor = constructorTerm == null ? null : ((IStrategoNamed) constructorTerm).getName();
@@ -38,6 +42,8 @@ public class ProductionAttributes {
         this.isCaseInsensitive = isCaseInsensitive;
         this.isIndentPaddingLexical = isIndentPaddingLexical;
         this.isFlatten = isFlatten;
+        this.nonAssocWith = nonAssocWith;
+        this.nonNestedWith = nonNestedWith;
     }
 
     public boolean isCompletion() {

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/deepconflicts/ContextualProduction.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/deepconflicts/ContextualProduction.java
@@ -221,10 +221,6 @@ public final class ContextualProduction implements IProduction, Serializable {
     }
 
 
-    public IStrategoTerm toAterm(SetMultimap<IProduction, IAttribute> prod_attrs) {
-        return getOrigProduction().toAterm(prod_attrs);
-    }
-
     public IStrategoTerm toSDF3Aterm(SetMultimap<IProduction, IAttribute> prod_attrs,
         Map<Set<Context>, Integer> ctx_vals, Integer ctx_val) {
         ITermFactory tf = ParseTableIO.getTermfactory();

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/AssociativityInfo.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/AssociativityInfo.java
@@ -1,11 +1,11 @@
 package org.metaborg.sdf2table.grammar;
 
-import static org.metaborg.sdf2table.parsetable.ParseTableProduction.getAllProductionLabels;
-
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
+import org.metaborg.sdf2table.deepconflicts.ContextualProduction;
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermFactory;
@@ -43,4 +43,15 @@ public class AssociativityInfo implements Serializable {
             tf.makeAppl(tf.makeConstructor("non-assoc", 1), tf.makeList(nonAssocLabels)),
             tf.makeAppl(tf.makeConstructor("non-nested", 1), tf.makeList(nonNestedLabels)));
     }
+
+    // If the production `p` is a regular production, this means that `labels` contains a label for it.
+    // If the production `p` is a contextual production, `labels` only contains contextual productions derived from `p`.
+    // In this case, return all labels for all contextual productions that have `p` as original production.
+    public static Stream<Integer> getAllProductionLabels(BiMap<IProduction, Integer> labels, Production p) {
+        return labels.containsKey(p) ? Stream.of(labels.get(p))
+            : labels.keySet().stream().filter(
+                cp -> cp instanceof ContextualProduction && ((ContextualProduction) cp).getOrigProduction().equals(p))
+                .map(labels::get);
+    }
+
 }

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/AssociativityInfo.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/AssociativityInfo.java
@@ -1,0 +1,46 @@
+package org.metaborg.sdf2table.grammar;
+
+import static org.metaborg.sdf2table.parsetable.ParseTableProduction.getAllProductionLabels;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.ITermFactory;
+
+import com.google.common.collect.BiMap;
+
+public class AssociativityInfo implements Serializable {
+
+    private static final long serialVersionUID = 8078429805984018592L;
+
+    private final Set<Production> nonAssocWith = new HashSet<>();
+    private final Set<Production> nonNestedWith = new HashSet<>();
+
+    protected AssociativityInfo() {
+    }
+
+    public Set<Production> getNonAssocWith() {
+        return nonAssocWith;
+    }
+
+    public Set<Production> getNonNestedWith() {
+        return nonNestedWith;
+    }
+
+    public IStrategoTerm toAterm(ITermFactory tf, BiMap<IProduction, Integer> productionLabels) {
+        IStrategoList.Builder nonAssocLabels = tf.arrayListBuilder(nonAssocWith.size());
+        IStrategoList.Builder nonNestedLabels = tf.arrayListBuilder(nonNestedWith.size());
+
+        for(Production p : nonAssocWith)
+            getAllProductionLabels(productionLabels, p).forEach(label -> nonAssocLabels.add(tf.makeInt(label)));
+        for(Production p : nonNestedWith)
+            getAllProductionLabels(productionLabels, p).forEach(label -> nonNestedLabels.add(tf.makeInt(label)));
+
+        return tf.makeAppl(tf.makeConstructor("assoc-with", 2),
+            tf.makeAppl(tf.makeConstructor("non-assoc", 1), tf.makeList(nonAssocLabels)),
+            tf.makeAppl(tf.makeConstructor("non-nested", 1), tf.makeList(nonNestedLabels)));
+    }
+}

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/NormGrammar.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/NormGrammar.java
@@ -9,13 +9,7 @@ import java.util.Set;
 import org.metaborg.sdf2table.deepconflicts.ContextualProduction;
 import org.metaborg.sdf2table.deepconflicts.ContextualSymbol;
 
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.LinkedHashMultimap;
-import com.google.common.collect.Maps;
-import com.google.common.collect.SetMultimap;
-import com.google.common.collect.Sets;
+import com.google.common.collect.*;
 
 public class NormGrammar implements INormGrammar, Serializable {
 
@@ -84,12 +78,6 @@ public class NormGrammar implements INormGrammar, Serializable {
     // expression grammars collapsed
     private final Set<Set<IProduction>> combinedExpressionGrammars;
 
-    // indirectly recursive symbols
-    private final SetMultimap<Symbol, Symbol> indirectlyRecursive;
-
-    // non-recursive symbols
-    private final SetMultimap<Symbol, Symbol> nonRecursive;
-    
     // left and right derivable symbols from a symbol
     private final SetMultimap<ISymbol, ISymbol> leftDerivable;
     private final SetMultimap<ISymbol, ISymbol> rightDerivable;
@@ -127,8 +115,6 @@ public class NormGrammar implements INormGrammar, Serializable {
         this.literalProductionsMapping = HashMultimap.create();
         this.expressionGrammars = HashMultimap.create();
         this.combinedExpressionGrammars = Sets.newHashSet();
-        this.indirectlyRecursive = HashMultimap.create();
-        this.nonRecursive = HashMultimap.create();
         this.leftDerivable = HashMultimap.create();
         this.rightDerivable = HashMultimap.create();
     }
@@ -289,14 +275,6 @@ public class NormGrammar implements INormGrammar, Serializable {
         return expressionGrammars;
     }
 
-    public SetMultimap<Symbol, Symbol> getIndirectlyRecursive() {
-        return indirectlyRecursive;
-    }
-
-    public SetMultimap<Symbol, Symbol> getNonRecursive() {
-        return nonRecursive;
-    }
-
     public Set<Set<IProduction>> getCombinedExpressionGrammars() {
         return combinedExpressionGrammars;
     }
@@ -328,7 +306,6 @@ public class NormGrammar implements INormGrammar, Serializable {
         this.contextualSymbols.clear();
         this.derivedContextualProds.clear();
         this.expressionGrammars.clear();
-        this.indirectlyRecursive.clear();
         this.leftRecursiveSymbolsMapping.clear();
         this.rightRecursiveSymbolsMapping.clear();
         this.literalProductionsMapping.clear();
@@ -336,7 +313,6 @@ public class NormGrammar implements INormGrammar, Serializable {
         this.longestMatchProdsFront.clear();
         this.nonAssocPriorities.clear();
         this.nonNestedPriorities.clear();
-        this.nonRecursive.clear();
         this.nonTransitivePriorities.clear();
         this.nonTransitivePriorityArgs.clear();
         this.productionsOnPriorities.clear();

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/NormGrammar.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/NormGrammar.java
@@ -60,8 +60,8 @@ public class NormGrammar implements INormGrammar, Serializable {
     private final SetMultimap<Production, Priority> higherPriorityProductions;
 
     // non-assoc and non-nested priorities that should shown as warnings to the user
-    private final SetMultimap<String, String> nonAssocPriorities;
-    private final SetMultimap<String, String> nonNestedPriorities;
+    private final SetMultimap<String, String> nonAssocProductions;
+    private final SetMultimap<String, String> nonNestedProductions;
 
     private final HashMap<String, Symbol> cacheSymbolsRead; // caching symbols read
     private final HashMap<String, Production> cacheProductionsRead; // caching productions read
@@ -106,8 +106,8 @@ public class NormGrammar implements INormGrammar, Serializable {
         this.transitivePriorityArgs = HashMultimap.create();
         this.nonTransitivePriorityArgs = HashMultimap.create();
         this.higherPriorityProductions = HashMultimap.create();
-        this.nonAssocPriorities = HashMultimap.create();
-        this.nonNestedPriorities = HashMultimap.create();
+        this.nonAssocProductions = HashMultimap.create();
+        this.nonNestedProductions = HashMultimap.create();
         this.symbolProductionsMapping = HashMultimap.create();
         this.cacheSymbolsRead = Maps.newHashMap();
         this.cacheProductionsRead = Maps.newHashMap();
@@ -279,8 +279,8 @@ public class NormGrammar implements INormGrammar, Serializable {
         return combinedExpressionGrammars;
     }
 
-    public SetMultimap<String, String> getNonAssocPriorities() {
-        return nonAssocPriorities;
+    public SetMultimap<String, String> getNonAssocProductions() {
+        return nonAssocProductions;
     }
 
     public void setInitialProduction(Production prod) {
@@ -291,8 +291,8 @@ public class NormGrammar implements INormGrammar, Serializable {
         return indexedPriorities;
     }
 
-    public SetMultimap<String, String> getNonNestedPriorities() {
-        return nonNestedPriorities;
+    public SetMultimap<String, String> getNonNestedProductions() {
+        return nonNestedProductions;
     }
 
     public GrammarFactory getGrammarFactory() {
@@ -311,8 +311,8 @@ public class NormGrammar implements INormGrammar, Serializable {
         this.literalProductionsMapping.clear();
         this.longestMatchProdsBack.clear();
         this.longestMatchProdsFront.clear();
-        this.nonAssocPriorities.clear();
-        this.nonNestedPriorities.clear();
+        this.nonAssocProductions.clear();
+        this.nonNestedProductions.clear();
         this.nonTransitivePriorities.clear();
         this.nonTransitivePriorityArgs.clear();
         this.productionsOnPriorities.clear();

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/NormGrammar.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/NormGrammar.java
@@ -59,10 +59,6 @@ public class NormGrammar implements INormGrammar, Serializable {
     private final SetMultimap<Priority, Integer> nonTransitivePriorityArgs;
     private final SetMultimap<Production, Priority> higherPriorityProductions;
 
-    // non-assoc and non-nested priorities that should shown as warnings to the user
-    private final SetMultimap<String, String> nonAssocProductions;
-    private final SetMultimap<String, String> nonNestedProductions;
-
     private final HashMap<String, Symbol> cacheSymbolsRead; // caching symbols read
     private final HashMap<String, Production> cacheProductionsRead; // caching productions read
 
@@ -106,8 +102,6 @@ public class NormGrammar implements INormGrammar, Serializable {
         this.transitivePriorityArgs = HashMultimap.create();
         this.nonTransitivePriorityArgs = HashMultimap.create();
         this.higherPriorityProductions = HashMultimap.create();
-        this.nonAssocProductions = HashMultimap.create();
-        this.nonNestedProductions = HashMultimap.create();
         this.symbolProductionsMapping = HashMultimap.create();
         this.cacheSymbolsRead = Maps.newHashMap();
         this.cacheProductionsRead = Maps.newHashMap();
@@ -279,20 +273,12 @@ public class NormGrammar implements INormGrammar, Serializable {
         return combinedExpressionGrammars;
     }
 
-    public SetMultimap<String, String> getNonAssocProductions() {
-        return nonAssocProductions;
-    }
-
     public void setInitialProduction(Production prod) {
         this.initialProduction = prod;
     }
 
     public SetMultimap<Priority, Integer> getIndexedPriorities() {
         return indexedPriorities;
-    }
-
-    public SetMultimap<String, String> getNonNestedProductions() {
-        return nonNestedProductions;
     }
 
     public GrammarFactory getGrammarFactory() {
@@ -311,9 +297,6 @@ public class NormGrammar implements INormGrammar, Serializable {
         this.literalProductionsMapping.clear();
         this.longestMatchProdsBack.clear();
         this.longestMatchProdsFront.clear();
-        // TODO: these maps are used in JSGLR1 to generate warnings for non-assoc and non-nested.
-        // this.nonAssocProductions.clear();
-        // this.nonNestedProductions.clear();
         this.nonTransitivePriorities.clear();
         this.nonTransitivePriorityArgs.clear();
         this.productionsOnPriorities.clear();

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/NormGrammar.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/NormGrammar.java
@@ -311,8 +311,9 @@ public class NormGrammar implements INormGrammar, Serializable {
         this.literalProductionsMapping.clear();
         this.longestMatchProdsBack.clear();
         this.longestMatchProdsFront.clear();
-        this.nonAssocProductions.clear();
-        this.nonNestedProductions.clear();
+        // TODO: these maps are used in JSGLR1 to generate warnings for non-assoc and non-nested.
+        // this.nonAssocProductions.clear();
+        // this.nonNestedProductions.clear();
         this.nonTransitivePriorities.clear();
         this.nonTransitivePriorityArgs.clear();
         this.productionsOnPriorities.clear();

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/io/NormGrammarReader.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/io/NormGrammarReader.java
@@ -538,6 +538,8 @@ public class NormGrammarReader {
                             return gf.createGeneralAttribute("assoc");
                         case "NonAssoc":
                             return gf.createGeneralAttribute("non-assoc");
+                        case "NonNested":
+                            return gf.createGeneralAttribute("non-nested");
                         default:
                             System.err.println("Unknown associativity: `" + assoc.getName() + "'.");
                             break;
@@ -866,6 +868,8 @@ public class NormGrammarReader {
 
                 grammar.getNonAssocProductions().put(higherSort + "." + higherConstructor,
                     lowerSort + "." + lowerConstructor);
+
+                p.higher().putNonAssociativity(p.lower());
             } else if(assoc.contains("NonNested")) {
                 // add warning for non-nested
                 String higherSort = Symbol.getSort(p.higher().leftHand());
@@ -876,6 +880,8 @@ public class NormGrammarReader {
 
                 grammar.getNonNestedProductions().put(higherSort + "." + higherConstructor,
                     lowerSort + "." + lowerConstructor);
+
+                p.higher().putNonNested(p.lower());
             }
 
         } else {

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/io/NormGrammarReader.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/io/NormGrammarReader.java
@@ -838,9 +838,8 @@ public class NormGrammarReader {
 
         } else if(TermUtils.isAppl(chain) && ((IStrategoAppl) chain).getName().equals("Assoc")) {
             IStrategoTerm first_group = chain.getSubterm(0);
-            IStrategoTerm assoc = chain.getSubterm(1);
+            String assoc = chain.getSubterm(1).toString();
             IStrategoTerm second_group = chain.getSubterm(2);
-
 
             Production higher = processGroup(first_group);
             Production lower = processGroup(second_group);
@@ -850,11 +849,11 @@ public class NormGrammarReader {
             grammar.getNonTransitivePriorities().add(p);
 
             // actual argument values will be processed later when defining recursion
-            if(assoc.toString().contains("Left")) {
+            if(assoc.contains("Left")) {
                 grammar.getNonTransitivePriorityArgs().put(p, Integer.MAX_VALUE);
-            } else if(assoc.toString().contains("Right")) {
+            } else if(assoc.contains("Right")) {
                 grammar.getNonTransitivePriorityArgs().put(p, Integer.MIN_VALUE);
-            } else if(assoc.toString().contains("NonAssoc")) {
+            } else if(assoc.contains("NonAssoc")) {
                 // consider non-assoc as left and add warning
                 // grammar.getNonTransitivePriorityArgs().put(p, Integer.MIN_VALUE);
                 grammar.getNonTransitivePriorityArgs().put(p, Integer.MAX_VALUE);
@@ -867,7 +866,7 @@ public class NormGrammarReader {
 
                 grammar.getNonAssocPriorities().put(higherSort + "." + higherConstructor,
                     lowerSort + "." + lowerConstructor);
-            } else if(assoc.toString().contains("NonNested")) {
+            } else if(assoc.contains("NonNested")) {
                 // add warning for non-nested
                 String higherSort = Symbol.getSort(p.higher().leftHand());
                 String higherConstructor = grammar.getConstructors().get(p.higher()).getConstructor();

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/io/NormGrammarReader.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/io/NormGrammarReader.java
@@ -860,27 +860,9 @@ public class NormGrammarReader {
                 // grammar.getNonTransitivePriorityArgs().put(p, Integer.MIN_VALUE);
                 grammar.getNonTransitivePriorityArgs().put(p, Integer.MAX_VALUE);
 
-                String higherSort = Symbol.getSort(p.higher().leftHand());
-                String higherConstructor = grammar.getConstructors().get(p.higher()).getConstructor();
-
-                String lowerSort = Symbol.getSort(p.lower().leftHand());
-                String lowerConstructor = grammar.getConstructors().get(p.lower()).getConstructor();
-
-                grammar.getNonAssocProductions().put(higherSort + "." + higherConstructor,
-                    lowerSort + "." + lowerConstructor);
-
                 p.higher().putNonAssociativity(p.lower());
             } else if(assoc.contains("NonNested")) {
                 // add warning for non-nested
-                String higherSort = Symbol.getSort(p.higher().leftHand());
-                String higherConstructor = grammar.getConstructors().get(p.higher()).getConstructor();
-
-                String lowerSort = Symbol.getSort(p.lower().leftHand());
-                String lowerConstructor = grammar.getConstructors().get(p.lower()).getConstructor();
-
-                grammar.getNonNestedProductions().put(higherSort + "." + higherConstructor,
-                    lowerSort + "." + lowerConstructor);
-
                 p.higher().putNonNested(p.lower());
             }
 

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/io/NormGrammarReader.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/io/NormGrammarReader.java
@@ -63,7 +63,7 @@ public class NormGrammarReader {
 
     public void addModuleAst(IStrategoTerm module) {
         if(module instanceof IStrategoAppl) {
-            IStrategoAppl app = (IStrategoAppl)module;
+            IStrategoAppl app = (IStrategoAppl) module;
             if(app.getName().equals("Module")) {
                 String modName = moduleName(app);
                 moduleAsts.put(modName, module);
@@ -864,7 +864,7 @@ public class NormGrammarReader {
                 String lowerSort = Symbol.getSort(p.lower().leftHand());
                 String lowerConstructor = grammar.getConstructors().get(p.lower()).getConstructor();
 
-                grammar.getNonAssocPriorities().put(higherSort + "." + higherConstructor,
+                grammar.getNonAssocProductions().put(higherSort + "." + higherConstructor,
                     lowerSort + "." + lowerConstructor);
             } else if(assoc.contains("NonNested")) {
                 // add warning for non-nested
@@ -874,7 +874,7 @@ public class NormGrammarReader {
                 String lowerSort = Symbol.getSort(p.lower().leftHand());
                 String lowerConstructor = grammar.getConstructors().get(p.lower()).getConstructor();
 
-                grammar.getNonNestedPriorities().put(higherSort + "." + higherConstructor,
+                grammar.getNonNestedProductions().put(higherSort + "." + higherConstructor,
                     lowerSort + "." + lowerConstructor);
             }
 

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/io/ParseTableIO.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/io/ParseTableIO.java
@@ -324,18 +324,4 @@ public class ParseTableIO implements IParseTableGenerator {
         return ccFactory;
     }
 
-    @Override public SetMultimap<String, String> getNonAssocProductions() {
-        if(tableCreated) {
-            return pt.normalizedGrammar().getNonAssocProductions();
-        }
-        return HashMultimap.create();
-    }
-
-    @Override public SetMultimap<String, String> getNonNestedProductions() {
-        if(tableCreated) {
-            return pt.normalizedGrammar().getNonNestedProductions();
-        }
-        return HashMultimap.create();
-    }
-
 }

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/io/ParseTableIO.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/io/ParseTableIO.java
@@ -349,28 +349,17 @@ public class ParseTableIO implements IParseTableGenerator {
         return ccFactory;
     }
 
-    @Override public SetMultimap<String, String> getNonAssocPriorities() {
-        SetMultimap<String, String> result = null;
+    @Override public SetMultimap<String, String> getNonAssocProductions() {
         if(tableCreated) {
-            result = pt.normalizedGrammar().getNonAssocPriorities();
+            return pt.normalizedGrammar().getNonAssocProductions();
         }
-
-        if(result != null)
-            return result;
-
         return HashMultimap.create();
     }
 
-    @Override public SetMultimap<String, String> getNonNestedPriorities() {
-        SetMultimap<String, String> result = null;
-
+    @Override public SetMultimap<String, String> getNonNestedProductions() {
         if(tableCreated) {
-            result = pt.normalizedGrammar().getNonNestedPriorities();
+            return pt.normalizedGrammar().getNonNestedProductions();
         }
-
-        if(result != null)
-            return result;
-
         return HashMultimap.create();
     }
 

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/io/ParseTableIO.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/io/ParseTableIO.java
@@ -1,13 +1,6 @@
 package org.metaborg.sdf2table.io;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
+import java.io.*;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -19,17 +12,8 @@ import org.metaborg.parsetable.characterclasses.CharacterClassFactory;
 import org.metaborg.parsetable.characterclasses.ICharacterClass;
 import org.metaborg.parsetable.states.IState;
 import org.metaborg.sdf2table.deepconflicts.ContextualProduction;
-import org.metaborg.sdf2table.grammar.IAttribute;
-import org.metaborg.sdf2table.grammar.IProduction;
-import org.metaborg.sdf2table.grammar.LexicalSymbol;
-import org.metaborg.sdf2table.grammar.NormGrammar;
-import org.metaborg.sdf2table.grammar.Priority;
-import org.metaborg.sdf2table.grammar.Production;
-import org.metaborg.sdf2table.parsetable.Action;
-import org.metaborg.sdf2table.parsetable.Goto;
-import org.metaborg.sdf2table.parsetable.ParseTable;
-import org.metaborg.sdf2table.parsetable.ParseTableConfiguration;
-import org.metaborg.sdf2table.parsetable.State;
+import org.metaborg.sdf2table.grammar.*;
+import org.metaborg.sdf2table.parsetable.*;
 import org.metaborg.util.log.ILogger;
 import org.metaborg.util.log.LoggerUtils;
 import org.spoofax.interpreter.terms.IStrategoList;
@@ -140,7 +124,7 @@ public class ParseTableIO implements IParseTableGenerator {
         IAttribute placeholder_insertion =
             pt.normalizedGrammar().getGrammarFactory().createGeneralAttribute("placeholder-insertion");
 
-        for(IProduction p : pt.productionLabels().keySet()) {  
+        for(IProduction p : pt.productionLabels().keySet()) {
             if(pt.isLayoutSymbol(p.leftHand())) {
                 continue;
             }
@@ -160,7 +144,7 @@ public class ParseTableIO implements IParseTableGenerator {
         }
 
         for(IProduction p : pt.productionLabels().keySet()) {
-            
+
             if(!recursiveSymbols.contains(p.leftHand())) {
                 continue;
             }
@@ -172,13 +156,13 @@ public class ParseTableIO implements IParseTableGenerator {
                 productions.add(((Production) p).toSDF3Aterm(pt.normalizedGrammar().getProductionAttributesMapping(),
                     pt.getCtxUniqueInt(), null));
             } else if(p instanceof ContextualProduction) {
-                Set<IAttribute> attrs = pt.normalizedGrammar().getProductionAttributesMapping().get(((ContextualProduction) p).getOrigProduction());
+                Set<IAttribute> attrs = pt.normalizedGrammar().getProductionAttributesMapping()
+                    .get(((ContextualProduction) p).getOrigProduction());
                 if(attrs.contains(placeholder)) {
                     continue;
                 }
-                productions
-                    .add(((ContextualProduction) p).toSDF3Aterm(pt.normalizedGrammar().getProductionAttributesMapping(),
-                        pt.getCtxUniqueInt(), null));
+                productions.add(((ContextualProduction) p)
+                    .toSDF3Aterm(pt.normalizedGrammar().getProductionAttributesMapping(), pt.getCtxUniqueInt(), null));
             }
 
         }
@@ -206,8 +190,7 @@ public class ParseTableIO implements IParseTableGenerator {
             for(Goto goto_action : s.gotos()) {
                 goto_terms.add(goto_action.toAterm(termFactory));
             }
-            IStrategoList.Builder
-                action_terms = termFactory.arrayListBuilder(s.actionsMapping().keySet().size());
+            IStrategoList.Builder action_terms = termFactory.arrayListBuilder(s.actionsMapping().keySet().size());
             for(ICharacterClass cc : s.actionsMapping().keySet()) {
                 final Set<Action> actionSet = s.actionsMapping().get(cc);
                 IStrategoList.Builder actions = termFactory.arrayListBuilder(actionSet.size());
@@ -270,19 +253,11 @@ public class ParseTableIO implements IParseTableGenerator {
 
         for(int i = 257 + pt.productionLabels().size() - 1; i >= 257; i--) {
             IProduction p = pt.productionLabels().inverse().get(i);
-            IStrategoTerm p_term;
-
-            if(p instanceof Production) {
-                p_term = termFactory.makeAppl(termFactory.makeConstructor("label", 2),
-                    ((Production) p).toAterm(pt.normalizedGrammar().getProductionAttributesMapping()),
-                    termFactory.makeInt(i));
-            } else {
-                p_term = termFactory.makeAppl(termFactory.makeConstructor("label", 2),
-                    ((ContextualProduction) p).toAterm(pt.normalizedGrammar().getProductionAttributesMapping()),
-                    termFactory.makeInt(i));
-            }
-
-            terms.add(p_term);
+            Production orig_p =
+                p instanceof Production ? (Production) p : ((ContextualProduction) p).getOrigProduction();
+            terms.add(termFactory.makeAppl(termFactory.makeConstructor("label", 2),
+                orig_p.toAterm(pt.normalizedGrammar().getProductionAttributesMapping(), pt.productionLabels()),
+                termFactory.makeInt(i)));
         }
 
         return termFactory.makeList(terms);
@@ -320,7 +295,7 @@ public class ParseTableIO implements IParseTableGenerator {
     public static void outputToFile(IStrategoTerm parseTable, File output) {
         logger.trace("Outputting parsetable without creating a string for it first. ");
         if(output != null) {
-            //noinspection ResultOfMethodCallIgnored
+            // noinspection ResultOfMethodCallIgnored
             output.getParentFile().mkdirs();
             try(final FileWriter out = new FileWriter(output)) {
                 parseTable.writeAsString(out);

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/parsetable/ParseTable.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/parsetable/ParseTable.java
@@ -1069,7 +1069,7 @@ public class ParseTable implements IParseTable, Serializable {
 
             ParseTableProduction prod = new ParseTableProduction(i + FIRST_PRODUCTION_LABEL, p,
                 grammar.getProductionAttributesMapping().get(orig_p), leftmostContextsMapping,
-                rightmostContextsMapping);
+                rightmostContextsMapping, labels);
             productions.add(prod);
             productionsMapping.put(p, prod);
         }

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/parsetable/ParseTableProduction.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/parsetable/ParseTableProduction.java
@@ -1,10 +1,11 @@
 package org.metaborg.sdf2table.parsetable;
 
+import static org.metaborg.sdf2table.grammar.AssociativityInfo.getAllProductionLabels;
+
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import org.metaborg.parsetable.characterclasses.ICharacterClass;
 import org.metaborg.parsetable.productions.ProductionType;
@@ -202,16 +203,6 @@ public class ParseTableProduction implements org.metaborg.parsetable.productions
                 .flatMap(o -> getAllProductionLabels(labels, o)).collect(ImmutableSet.toImmutableSet());
         } else
             nonAssocWith = nonNestedWith = null;
-    }
-
-    // If the production `p` is a regular production, this means that `labels` contains a label for it.
-    // If the production `p` is a contextual production, `labels` only contains contextual productions derived from `p`.
-    // In this case, return all labels for all contextual productions that have `p` as original production.
-    public static Stream<Integer> getAllProductionLabels(BiMap<IProduction, Integer> labels, Production p) {
-        return labels.containsKey(p) ? Stream.of(labels.get(p))
-            : labels.keySet().stream().filter(
-                cp -> cp instanceof ContextualProduction && ((ContextualProduction) cp).getOrigProduction().equals(p))
-                .map(labels::get);
     }
 
     private LayoutConstraintAttribute normalizeConstraint(LayoutConstraintAttribute attr, List<ISymbol> rightHand) {


### PR DESCRIPTION
To be merged together with metaborg/jsglr#86 and metaborg/spoofax#73. Recommended order of reading: SDF, JSGLR, Spoofax.

This PR starts with four minor refactoring commits, and after those, the fun stuff happens. :smile: 

Instead of globally keeping a list of pairs of mutually non-associative productions, each production now stores for itself in a `Set<Production>` which other productions it is non-associative with. This is done in [NormGrammarReader.java:858-866](https://github.com/metaborg/sdf/compare/master...mpsijm:non-assoc-warnings?expand=1#diff-26353ed93945b76e7df87914f87e6e79R858-R866).

When converting the grammar productions to parse table productions, for each production, their `Set<Production> nonAssocWith` is converted into a `Set<Integer>` representing the labels of the productions ([ParseTableProduction.java:198-205](https://github.com/metaborg/sdf/compare/master...mpsijm:non-assoc-warnings?expand=1#diff-bea03ca5aa7f6d860d90059a5ebdc575R198-R205)). This requires some fiddling in the case of data-dependent parsing, because from one production, many contextual productions may be created. All created contextual productions are stored in the `Set<Integer> nonAssocWith` for this production. This generates some overhead by iterating over all productions, see [AssociativityInfo.java:52-54](https://github.com/metaborg/sdf/compare/master...mpsijm:non-assoc-warnings?expand=1#diff-e59e347378dbe9687b9af7554f1cf888R52-R54) (this overhead can possibly be reduced if the `NormGrammar.prodContextualProdMapping` were a `MultiMap` instead of a `BiMap`).

Finally, the `nonAssocWith` list is stored as part of a production's attribute when it is generated to ATerm format. Example of such an attribute: `assoc-with(non-assoc([337]),non-nested([]))`. The parse table readers have of course been adapted to recognize this attribute (for JSGLR1: see metaborg/jsglr#86, for JSGLR2: [org.metaborg.parsetable.productions.ProductionReader.java:162-183](https://github.com/metaborg/sdf/compare/master...mpsijm:non-assoc-warnings?expand=1#diff-b68677a7403f03571895189295897d2dR162-R183)

Note that all of the above is also applicable to `non-nested`. I decided to keep supporting both, because `non-assoc` gives a left-recursive AST while `non-nested` gives a right-recursive AST.