### PR TITLE
Feature: new layout constraint syntax

### DIFF
--- a/org.metaborg.meta.lang.template.test/layout-constraints/syntax.spt
+++ b/org.metaborg.meta.lang.template.test/layout-constraints/syntax.spt
@@ -1,0 +1,90 @@
+module layout-constraints/syntax
+
+language TemplateLang
+
+fixture [[
+module test
+
+context-free syntax
+  A.A = "1" {layout([[...]])}
+]]
+
+test nat constraint [[2]] parse fails
+test nat add constraint [[2 + 3]] parse fails
+test nat sub constraint [[3 - 2]] parse fails
+test nat mul constraint [[1 * 2]] parse fails
+test nat div constraint [[1 / 2]] parse fails
+test nat eq constraint [[1 == 2]] parse fails
+test nat gt constraint [[1 > 2]] parse fails
+test nat ge constraint [[1 >= 2]] parse fails
+test nat lt constraint [[1 < 2]] parse fails
+test nat le constraint [[1 <= 2]] parse fails
+
+test index constraint [[1.first.col]] parse fails
+test index add constraint [[1.first.col + 1]] parse fails
+test index add index constraint [[1.first.col + 2.first.col]] parse fails
+
+test index first col [[1.first.col == 1.first.col]] parse succeeds
+test index first line [[1.first.line == 1.first.line]] parse succeeds
+test index left col [[1.left.col == 1.left.col]] parse succeeds
+test index left line [[1.left.line == 1.left.line]] parse succeeds
+test index right col [[1.right.col == 1.right.col]] parse succeeds
+test index right line [[1.right.line == 1.right.line]] parse succeeds
+test index last col [[1.last.col == 1.last.col]] parse succeeds
+test index last line [[1.last.line == 1.last.line]] parse succeeds
+
+test ref constraint [[ref1.first.line == ref2.last.line]] parse succeeds
+
+test index eq constraint [[1.first.col == 1]] parse succeeds
+test index gt constraint [[1.first.col > 1]] parse succeeds
+test index ge constraint [[1.first.col >= 1]] parse succeeds
+test index lt constraint [[1.first.col < 1]] parse succeeds
+test index le constraint [[1.first.col <= 1]] parse succeeds
+
+test index eq index constraint [[1.first.col == 1.first.col]] parse succeeds
+test index gt index constraint [[1.first.col > 1.first.col]] parse succeeds
+test index ge index constraint [[1.first.col >= 1.first.col]] parse succeeds
+test index lt index constraint [[1.first.col < 1.first.col]] parse succeeds
+test index le index constraint [[1.first.col <= 1.first.col]] parse succeeds
+
+test not constraint [[!1.first.col == 2.first.col]] parse succeeds
+test not index constraint [[!1.first.col]] parse fails
+test not nat constraint [[!2]] parse fails
+test and constraint [[1.first.col == 0 && 2.first.col == 0]] parse succeeds
+test or constraint [[1.first.col == 0 || 2.first.col == 0]] parse succeeds
+test logical priority constraint [[!(1.first.col < 1 + 2 * 3 && 2.first.col > 2)]]
+parse to Not(And(Lt(Col(First(Tree("1"))),Add(Num("1"),Mul(Num("2"),Num("3")))),Gt(Col(First(Tree("2"))),Num("2"))))
+
+test nat [[offside 1 2]] parse succeeds
+test nat ref [[offside 2 other]] parse succeeds
+
+test offside [[offside ref]] parse succeeds
+test offside none [[offside]] parse fails
+test offside one [[offside ref other]] parse succeeds
+test offside more [[offside ref other, this, that]] parse succeeds
+
+test indent none [[indent ref]] parse fails
+test indent none [[indent]] parse fails
+test indent one [[indent ref other]] parse succeeds
+test indent more [[indent ref other, more]] parse succeeds
+
+test align none [[align ref]] parse fails
+test align one [[align ref other]] parse succeeds
+test align more [[align ref other, more]] parse succeeds
+test align more non-separated [[align ref other more]] parse fails
+
+test align-list none [[align-list]] parse fails
+test align-list [[align-list list]] parse succeeds
+test align-list more [[align-list this that]] parse fails
+
+test newline-indent none [[newline-indent]] parse fails
+test newline-indent with none [[newline-indent ref]] parse fails
+test newline-indent one [[newline-indent ref other]] parse succeeds
+test newline-indent more [[newline-indent ref other, more]] parse succeeds
+test newline-indent more non-separated [[newline-indent ref other more]] parse fails
+
+test not declaration [[!offside ref]] parse fails
+test declaration and declaration [[align this that && indent that other]] parse succeeds
+test declaration or declaration [[align this that || align this other]] parse succeeds
+test declaratation and constraint [[offside ref && other.first.line > ref.last.line]] parse succeeds
+test declaration or constraint [[offside ref || ref.first.line == other.last.line]] parse succeeds

--- a/org.metaborg.meta.lang.template.test/layout-constraints/syntax.spt
+++ b/org.metaborg.meta.lang.template.test/layout-constraints/syntax.spt
@@ -14,11 +14,11 @@ test nat add constraint [[2 + 3]] parse fails
 test nat sub constraint [[3 - 2]] parse fails
 test nat mul constraint [[1 * 2]] parse fails
 test nat div constraint [[1 / 2]] parse fails
-test nat eq constraint [[1 == 2]] parse fails
-test nat gt constraint [[1 > 2]] parse fails
-test nat ge constraint [[1 >= 2]] parse fails
-test nat lt constraint [[1 < 2]] parse fails
-test nat le constraint [[1 <= 2]] parse fails
+test nat eq constraint [[1 == 2]] parse succeeds
+test nat gt constraint [[1 > 2]] parse succeeds
+test nat ge constraint [[1 >= 2]] parse succeeds
+test nat lt constraint [[1 < 2]] parse succeeds
+test nat le constraint [[1 <= 2]] parse succeeds
 
 test index constraint [[1.first.col]] parse fails
 test index add constraint [[1.first.col + 1]] parse fails
@@ -53,7 +53,7 @@ test not nat constraint [[!2]] parse fails
 test and constraint [[1.first.col == 0 && 2.first.col == 0]] parse succeeds
 test or constraint [[1.first.col == 0 || 2.first.col == 0]] parse succeeds
 test logical priority constraint [[!(1.first.col < 1 + 2 * 3 && 2.first.col > 2)]]
-parse to Not(And(Lt(Col(First(Tree("1"))),Add(Num("1"),Mul(Num("2"),Num("3")))),Gt(Col(First(Tree("2"))),Num("2"))))
+parse to Not(And(Lt(Col(First(PosRef("1"))),Add(Num("1"),Mul(Num("2"),Num("3")))),Gt(Col(First(PosRef("2"))),Num("2"))))
 
 test nat [[offside 1 2]] parse succeeds
 test nat ref [[offside 2 other]] parse succeeds
@@ -83,7 +83,7 @@ test newline-indent one [[newline-indent ref other]] parse succeeds
 test newline-indent more [[newline-indent ref other, more]] parse succeeds
 test newline-indent more non-separated [[newline-indent ref other more]] parse fails
 
-test not declaration [[!offside ref]] parse fails
+test not declaration [[!offside ref]] parse succeeds
 test declaration and declaration [[align this that && indent that other]] parse succeeds
 test declaration or declaration [[align this that || align this other]] parse succeeds
 test declaratation and constraint [[offside ref && other.first.line > ref.last.line]] parse succeeds

--- a/org.metaborg.meta.lang.template.test/layout-constraints/syntax.spt
+++ b/org.metaborg.meta.lang.template.test/layout-constraints/syntax.spt
@@ -14,6 +14,7 @@ test nat add constraint [[2 + 3]] parse fails
 test nat sub constraint [[3 - 2]] parse fails
 test nat mul constraint [[1 * 2]] parse fails
 test nat div constraint [[1 / 2]] parse fails
+
 test nat eq constraint [[1 == 2]] parse succeeds
 test nat gt constraint [[1 > 2]] parse succeeds
 test nat ge constraint [[1 >= 2]] parse succeeds
@@ -47,13 +48,29 @@ test index ge index constraint [[1.first.col >= 1.first.col]] parse succeeds
 test index lt index constraint [[1.first.col < 1.first.col]] parse succeeds
 test index le index constraint [[1.first.col <= 1.first.col]] parse succeeds
 
+test non assoc eq [[1.first.col == 2.first.col == 3.first.col]] parse fails
+test non assoc gt [[1.first.col > 2.first.col > 3.first.col]] parse fails
+test non assoc ge [[1.first.col >= 2.first.col >= 3.first.col]] parse fails
+test non assoc lt [[1.first.col < 2.first.col < 3.first.col]] parse fails
+test non assoc le [[1.first.col <= 2.first.col <= 3.first.col]] parse fails
+
 test not constraint [[!1.first.col == 2.first.col]] parse succeeds
 test not index constraint [[!1.first.col]] parse fails
 test not nat constraint [[!2]] parse fails
 test and constraint [[1.first.col == 0 && 2.first.col == 0]] parse succeeds
 test or constraint [[1.first.col == 0 || 2.first.col == 0]] parse succeeds
+
 test logical priority constraint [[!(1.first.col < 1 + 2 * 3 && 2.first.col > 2)]]
 parse to Not(And(Lt(Col(First(PosRef("1"))),Add(Num("1"),Mul(Num("2"),Num("3")))),Gt(Col(First(PosRef("2"))),Num("2"))))
+test and priority over or [[1 == 1 || 2 == 2 && 3 == 3]]
+parse to Or(Eq(Num("1"),Num("1")),And(Eq(Num("2"),Num("2")),Eq(Num("3"),Num("3"))))
+test not priority over and [[!1 == 1 && 2 == 2]]
+parse to And(Not(Eq(Num("1"),Num("1"))),Eq(Num("2"),Num("2")))
+test not priority over or [[!1 == 1 || 2 == 2]]
+parse to Or(Not(Eq(Num("1"),Num("1"))),Eq(Num("2"),Num("2")))
+
+test constraint with braces [[((1 == ((2 - 2) + (3 * 4))) && (2 == 2))]] parse succeeds
+
 
 test nat [[offside 1 2]] parse succeeds
 test nat ref [[offside 2 other]] parse succeeds
@@ -62,6 +79,7 @@ test offside [[offside ref]] parse succeeds
 test offside none [[offside]] parse fails
 test offside one [[offside ref other]] parse succeeds
 test offside more [[offside ref other, this, that]] parse succeeds
+test offside no space between keyword [[offsideref]] parse fails
 
 test indent none [[indent ref]] parse fails
 test indent none [[indent]] parse fails

--- a/org.metaborg.meta.lang.template/syntax/kernel/Kernel.sdf3
+++ b/org.metaborg.meta.lang.template/syntax/kernel/Kernel.sdf3
@@ -31,8 +31,7 @@ Attribute.Avoid = <avoid> {deprecated("Prefer and avoid are deprecated and will 
 Attribute.Bracket = <bracket>
 Attribute.Assoc = <<Associativity>>
 
-Attribute.LayoutConstraint = <layout(<Constraint>)> 
-Attribute.LayoutConstraint = <layout(<ShortConstraint>)> 
+Attribute.LayoutConstraint = <layout(<Constraint>)>
 
 Attribute.IgnoreLayout = <ignore-layout>
 Attribute.EnforceNewLine = <enforce-newline>

--- a/org.metaborg.meta.lang.template/syntax/layout-constraints/Layout-Constraints.sdf3
+++ b/org.metaborg.meta.lang.template/syntax/layout-constraints/Layout-Constraints.sdf3
@@ -21,68 +21,73 @@ template options
   LayoutVar = keyword {restrict}
   keyword -/- [a-zA-Z0-9]
 
+context-free sorts
+
+  Constraint
+  ConstraintExp
+  ConstraintToken
+  ConstraintTreeRef
+
 context-free syntax
 
-  ConstraintTree.Tree = NatCon
-  Constraint.Num = NatCon
-  Constraint = LayoutVar
-  Constraint.All = <all(<LayoutVar>, <Constraint>, <Constraint> )> {deprecated("all layout constraint will be removed in a future version. Use align-list instead")}
-  ConstraintToken.First = <<ConstraintTree>.first>
-  ConstraintToken.Left = <<ConstraintTree>.left>
-  ConstraintToken.Right = <<ConstraintTree>.right>
-  ConstraintToken.Last = <<ConstraintTree>.last>
-  Constraint.Line = <<ConstraintToken>.line>
-  Constraint.Col = <<ConstraintToken>.col>
-  Constraint.Mul = <<Constraint> * <Constraint>> {left}
-  Constraint.Div = <<Constraint> / <Constraint>> {left}
-  Constraint.Add = <<Constraint> + <Constraint>> {left}
-  Constraint.Sub = <<Constraint> - <Constraint>> {left}
-  Constraint.Eq = <<Constraint> == <Constraint>> {non-assoc}
-  Constraint.Lt = <<Constraint> \< <Constraint>> {non-assoc}
-  Constraint.Le = <<Constraint> \<= <Constraint>> {non-assoc}
-  Constraint.Gt = <<Constraint> \> <Constraint>> {non-assoc}
-  Constraint.Ge = <<Constraint> \>= <Constraint>> {non-assoc}
+  ConstraintTreeRef.PosRef = NatCon
+  ConstraintTreeRef.LiteralRef = StrCon
+  ConstraintTreeRef.LabelRef = IdCon
+
+  ConstraintToken.First = <<ConstraintTreeRef>.first>
+  ConstraintToken.Left = <<ConstraintTreeRef>.left>
+  ConstraintToken.Right = <<ConstraintTreeRef>.right>
+  ConstraintToken.Last = <<ConstraintTreeRef>.last>
+
+  ConstraintExp = <(<ConstraintExp>)> {bracket}
+  ConstraintExp.Mul = <<ConstraintExp> * <ConstraintExp>> {left}
+  ConstraintExp.Div = <<ConstraintExp> / <ConstraintExp>> {left}
+  ConstraintExp.Add = <<ConstraintExp> + <ConstraintExp>> {left}
+  ConstraintExp.Sub = <<ConstraintExp> - <ConstraintExp>> {left}
+  ConstraintExp.Line = <<ConstraintToken>.line>
+  ConstraintExp.Col = <<ConstraintToken>.col>
+  ConstraintExp.Num = NatCon
+  ConstraintExp.LayoutVar = LayoutVar
+
+  Constraint = <(<Constraint>)> {bracket}
+  Constraint.Eq = <<ConstraintExp> == <ConstraintExp>> {non-assoc}
+  Constraint.Lt = <<ConstraintExp> \< <ConstraintExp>> {non-assoc}
+  Constraint.Le = <<ConstraintExp> \<= <ConstraintExp>> {non-assoc}
+  Constraint.Gt = <<ConstraintExp> \> <ConstraintExp>> {non-assoc}
+  Constraint.Ge = <<ConstraintExp> \>= <ConstraintExp>> {non-assoc}
   Constraint.Not = <!<Constraint>>
   Constraint.And = <<Constraint> && <Constraint>> {left}
   Constraint.Or = <<Constraint> || <Constraint>> {left}
-  Constraint = <(<Constraint>)> {bracket}
 
-  ShortConstraint.And = <<ShortConstraint> && <ShortConstraint>> {left}
-  ShortConstraint.Or = <<ShortConstraint> || <ShortConstraint>> {left}
-  ShortConstraint = <(<ShortConstraint>)> {bracket}
+  Constraint.All = <all(<LayoutVar>, <Constraint>, <Constraint>)> {
+    deprecated("all layout constraint will be removed in a future version. Use align-list instead")}
 
-  ShortConstraint.Offside = <offside <ConstraintTreeReference> <{ConstraintTreeReference ", "}*>>
-  ShortConstraint.Indent = <indent <ConstraintTreeReference> <{ConstraintTreeReference ", "}+>>
-  ShortConstraint.Align = <align <ConstraintTreeReference> <{ConstraintTreeReference ", "}+>>
-  ShortConstraint.Align = <align-list <ConstraintTreeReference>>
-  ShortConstraint.NewLineIndent = <newline-indent <ConstraintTreeReference> <{ConstraintTreeReference ", "}+>>
+  Constraint.Offside = <offside <ConstraintTreeRef> <{ConstraintTreeRef ", "}*>>
+  Constraint.Indent = <indent <ConstraintTreeRef> <{ConstraintTreeRef ", "}+>>
+  Constraint.Align = <align <ConstraintTreeRef> <{ConstraintTreeRef ", "}+>>
+  Constraint.AlignList = <align-list <ConstraintTreeRef>>
+  Constraint.NewLineIndent = <newline-indent <ConstraintTreeRef> <{ConstraintTreeRef ", "}+>>
 
-  ShortConstraint.PPOffside = <pp-offside <ConstraintTreeReference> <{ConstraintTreeReference ", "}*>>
-  ShortConstraint.PPIndent = <pp-indent <ConstraintTreeReference> <{ConstraintTreeReference ", "}+>>
-  ShortConstraint.PPAlign = <pp-align <ConstraintTreeReference> <{ConstraintTreeReference ", "}+>>
-  ShortConstraint.PPAlign = <pp-align-list <ConstraintTreeReference>>
-  ShortConstraint.PPNewLineIndent = <pp-newline-indent <ConstraintTreeReference> <{ConstraintTreeReference ", "}+>>
-  ShortConstraint.PPNewLineIndentBy = <pp-newline-indent-by(<NatCon>) <ConstraintTreeReference> <{ConstraintTreeReference ", "}+>>
-  ShortConstraint.PPNewLine = <pp-newline <ConstraintTreeReference>>
-  ShortConstraint.PPNewLineBy = <pp-newline(<NatCon>) <ConstraintTreeReference>>
-
-  ConstraintTreeReference.PosRef = NatCon
-  ConstraintTreeReference.LiteralRef = StrCon
-  ConstraintTreeReference.LabelRef = IdCon
+  Constraint.PPOffside = <pp-offside <ConstraintTreeRef> <{ConstraintTreeRef ", "}*>>
+  Constraint.PPIndent = <pp-indent <ConstraintTreeRef> <{ConstraintTreeRef ", "}+>>
+  Constraint.PPAlign = <pp-align <ConstraintTreeRef> <{ConstraintTreeRef ", "}+>>
+  Constraint.PPAlignList = <pp-align-list <ConstraintTreeRef>>
+  Constraint.PPNewLineIndent = <pp-newline-indent <ConstraintTreeRef> <{ConstraintTreeRef ", "}+>>
+  Constraint.PPNewLineIndentBy = <pp-newline-indent-by(<NatCon>) <ConstraintTreeRef> <{ConstraintTreeRef ", "}+>>
+  Constraint.PPNewLine = <pp-newline <ConstraintTreeRef>>
+  Constraint.PPNewLineBy = <pp-newline(<NatCon>) <ConstraintTreeRef>>
 
 context-free priorities
 
-    Constraint.Not > {left:
-    Constraint.Mul
-    Constraint.Div } > {left:
-    Constraint.Add
-    Constraint.Sub} > {non-assoc:
-    Constraint.Eq
-    Constraint.Lt
-    Constraint.Le
-    Constraint.Gt
-    Constraint.Ge} > {left:
-    Constraint.And} > {left:
-    Constraint.Or},
+    Constraint.Not >
+    {non-assoc:
+      Constraint.Eq
+      Constraint.Lt
+      Constraint.Le
+      Constraint.Gt
+      Constraint.Ge
+    } >
+    {left: Constraint.And} >
+    {left: Constraint.Or},
 
-    {left: ShortConstraint.And ShortConstraint.Or}
+    {left: ConstraintExp.Mul ConstraintExp.Div } > {left: ConstraintExp.Add ConstraintExp.Sub}

--- a/org.metaborg.meta.lang.template/syntax/layout-constraints/Layout-Constraints.sdf3
+++ b/org.metaborg.meta.lang.template/syntax/layout-constraints/Layout-Constraints.sdf3
@@ -60,7 +60,7 @@ context-free syntax
   Constraint.Or = <<Constraint> || <Constraint>> {left}
 
   Constraint.All = <all(<LayoutVar>, <Constraint>, <Constraint>)> {
-    deprecated("all layout constraint will be removed in a future version. Use align-list instead")}
+    deprecated("The 'all' layout constraint will be removed in a future version. Use align-list instead")}
 
   Constraint.Offside = <offside <ConstraintTreeRef> <{ConstraintTreeRef ", "}*>>
   Constraint.Indent = <indent <ConstraintTreeRef> <{ConstraintTreeRef ", "}+>>

--- a/org.metaborg.meta.lang.template/syntax/layout-constraints/Layout-Constraints.sdf3
+++ b/org.metaborg.meta.lang.template/syntax/layout-constraints/Layout-Constraints.sdf3
@@ -87,7 +87,7 @@ context-free priorities
       Constraint.Gt
       Constraint.Ge
     } >
-    {left: Constraint.And} >
-    {left: Constraint.Or},
+    Constraint.And >
+    Constraint.Or,
 
     {left: ConstraintExp.Mul ConstraintExp.Div } > {left: ConstraintExp.Add ConstraintExp.Sub}

--- a/org.metaborg.meta.lang.template/syntax/sdf2-core/Sdf2.sdf3
+++ b/org.metaborg.meta.lang.template/syntax/sdf2-core/Sdf2.sdf3
@@ -72,7 +72,6 @@ context-free syntax
     ATermAttribute = <placeholder-insertion> {reject}
     ATermAttribute = <literal-completion> {reject}
     ATermAttribute = <layout(<Constraint>)> {reject}
-    ATermAttribute = <layout(<ShortConstraint>)> {reject}
     ATermAttribute = <deprecated(<StrCon>)> {reject}
     ATermAttribute.Constructor = <cons(<StrCon>)>{reject}
     ATermAttribute = <id(<ModuleName>)> {reject}

--- a/org.metaborg.meta.lang.template/syntax/sdf2-core/Sdf2.sdf3
+++ b/org.metaborg.meta.lang.template/syntax/sdf2-core/Sdf2.sdf3
@@ -1,6 +1,7 @@
 module sdf2-core/Sdf2
 
 imports 
+  aterms/Aterms
   sdf2-core/Sdf2-Syntax 
   constants/StrCon 
   constants/NatCon 
@@ -72,6 +73,7 @@ context-free syntax
     ATermAttribute = <placeholder-insertion> {reject}
     ATermAttribute = <literal-completion> {reject}
     ATermAttribute = <layout(<Constraint>)> {reject}
+    ATermAttribute = <layout(<ATerm>)> {reject}
     ATermAttribute = <deprecated(<StrCon>)> {reject}
     ATermAttribute.Constructor = <cons(<StrCon>)>{reject}
     ATermAttribute = <id(<ModuleName>)> {reject}

--- a/org.metaborg.meta.lang.template/trans/analysis/desugar.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/desugar.str
@@ -216,14 +216,14 @@ rules
   create-productions-align-list(|chars):
     SdfProduction(lhs, Rhs(rhs*), Attrs(attrs*)) -> prods*
     where
-      pos*           := <collect-all(?Align(<id>), collapse-lists); not(?[])> attrs*;
+      pos*           := <collect-all(?AlignList(<id>), collapse-lists); not(?[])> attrs*;
       non-terminals* := <map(get-non-terminal-symbol(|rhs*))> pos*;
       prods*         := <filter(generate-align-productions)> non-terminals*
 
   create-productions-align-list(|chars):
     SdfProductionWithCons(lhs, Rhs(rhs*), Attrs(attrs*)) -> prods*
     where
-      pos*           := <collect-all(?Align(<id>), collapse-lists); not(?[])> attrs*;
+      pos*           := <collect-all(?AlignList(<id>), collapse-lists); not(?[])> attrs*;
       non-terminals* := <map(get-non-terminal-symbol(|rhs*))> pos*;
       prods*         := <filter(generate-align-productions)> non-terminals*
 
@@ -231,7 +231,7 @@ rules
     t@TemplateProduction(lhs, rhs, Attrs(attrs*)) -> prods*
     where
       rhs*           := <get-production-rhs(|chars)> t;
-      pos*           := <collect-all(?Align(<id>), collapse-lists); not(?[])> attrs*;
+      pos*           := <collect-all(?AlignList(<id>), collapse-lists); not(?[])> attrs*;
       non-terminals* := <map(get-non-terminal-symbol(|rhs*))> pos*;
       prods*         := <filter(generate-align-productions)> non-terminals*
 
@@ -239,21 +239,21 @@ rules
     t@TemplateProductionWithCons(lhs, rhs, Attrs(attrs*)) -> prods*
     where
       rhs*           := <get-production-rhs(|chars)> t;
-      pos*           := <collect-all(?Align(<id>), collapse-lists); not(?[])> attrs*;
+      pos*           := <collect-all(?AlignList(<id>), collapse-lists); not(?[])> attrs*;
       non-terminals* := <map(get-non-terminal-symbol(|rhs*))> pos*;
       prods*         := <filter(generate-align-productions)> non-terminals*
 
   generate-align-productions:
-    Iter(s) -> SdfProduction(Iter(s), Rhs([Iter(s), s]), Attrs([LayoutConstraint(Eq(Col(First(Tree("0"))), Col(First(Tree("1")))))]))
+    Iter(s) -> SdfProduction(Iter(s), Rhs([Iter(s), s]), Attrs([LayoutConstraint(Eq(Col(First(PosRef("0"))), Col(First(PosRef("1")))))]))
 
   generate-align-productions:
-    IterStar(s) -> SdfProduction(Iter(s), Rhs([Iter(s), s]), Attrs([LayoutConstraint(Eq(Col(First(Tree("0"))), Col(First(Tree("1")))))]))
+    IterStar(s) -> SdfProduction(Iter(s), Rhs([Iter(s), s]), Attrs([LayoutConstraint(Eq(Col(First(PosRef("0"))), Col(First(PosRef("1")))))]))
 
   generate-align-productions:
-    IterSep(s, sep) -> SdfProduction(IterSep(s, sep), Rhs([IterSep(s, sep), sep, s]), Attrs([LayoutConstraint(Eq(Col(First(Tree("0"))), Col(First(Tree("2")))))]))
+    IterSep(s, sep) -> SdfProduction(IterSep(s, sep), Rhs([IterSep(s, sep), sep, s]), Attrs([LayoutConstraint(Eq(Col(First(PosRef("0"))), Col(First(PosRef("2")))))]))
 
   generate-align-productions:
-    IterStarSep(s, sep) -> SdfProduction(IterSep(s, sep), Rhs([IterSep(s, sep), sep, s]), Attrs([LayoutConstraint(Eq(Col(First(Tree("0"))), Col(First(Tree("2")))))]))
+    IterStarSep(s, sep) -> SdfProduction(IterSep(s, sep), Rhs([IterSep(s, sep), sep, s]), Attrs([LayoutConstraint(Eq(Col(First(PosRef("0"))), Col(First(PosRef("2")))))]))
 
   desugar-lc-prod(|chars):
     SdfProduction(lhs, Rhs(rhs*), Attrs(attrs*)) -> SdfProduction(lhs, Rhs(rhs*), Attrs(attrs'*))
@@ -323,15 +323,15 @@ rules
       constraint := <map(get-tree-position(|rhs*); create-align-constraint(|ref-pos')); flatten-list; combine-constraints> pos*
 
   get-tree-position(|rhs*):
-    PosRef(p) -> Tree(<dec> p)
+    PosRef(p) -> PosRef(<dec> p)
 
   get-tree-position(|rhs*):
-    LiteralRef(l) -> Tree(<dec; int-to-string> p)
+    LiteralRef(l) -> PosRef(<dec; int-to-string> p)
     where
       p := <get-index> (Lit(l), rhs*)
 
   get-tree-position(|rhs*):
-    LabelRef(l) -> Tree(<dec; int-to-string> p)
+    LabelRef(l) -> PosRef(<dec; int-to-string> p)
     where
       l'    := <strip-annos> l;
       rhs'* := <strip-annos> rhs*;
@@ -357,16 +357,16 @@ rules
       symbol := <fetch-elem(?Lit(l))> rhs*
 
   create-offside-constraint(|ref-pos):
-    Tree(p) -> Gt(Col(Left(Tree(p))), Col(First(ref-pos)))
+    PosRef(p) -> Gt(Col(Left(PosRef(p))), Col(First(ref-pos)))
 
   create-indent-constraint(|ref-pos):
-    Tree(p) -> Gt(Col(First(Tree(p))), Col(First(ref-pos)))
+    PosRef(p) -> Gt(Col(First(PosRef(p))), Col(First(ref-pos)))
 
   create-newline-indent-constraint(|ref-pos):
-    Tree(p) -> And(Gt(Col(First(Tree(p))), Col(First(ref-pos))), Gt(Line(First(Tree(p))), Line(Last(ref-pos))))
+    PosRef(p) -> And(Gt(Col(First(PosRef(p))), Col(First(ref-pos))), Gt(Line(First(PosRef(p))), Line(Last(ref-pos))))
 
   create-align-constraint(|ref-pos):
-    Tree(p) -> Eq(Col(First(Tree(p))), Col(First(ref-pos)))
+    PosRef(p) -> Eq(Col(First(PosRef(p))), Col(First(ref-pos)))
 
   remove-align-list-and-pp-constraints:
     And(<remove-constraint>, c) -> c
@@ -383,4 +383,4 @@ rules
   remove-align-list-and-pp-constraints:
     LayoutConstraint(<remove-constraint>) -> []
 
-  remove-constraint = ?Align(_) + ?PPAlign(_) + ?PPOffside(_, _) + ?PPIndent(_, _) + ?PPAlign(_, _) + ?PPNewLineIndent(_, _) + ?PPNewLineIndentBy(_, _, _) + ?PPNewLine(_) + ?PPNewLineBy(_, _)
+  remove-constraint = ?AlignList(_) + ?PPAlignList(_) + ?PPOffside(_, _) + ?PPIndent(_, _) + ?PPAlign(_, _) + ?PPNewLineIndent(_, _) + ?PPNewLineIndentBy(_, _, _) + ?PPNewLine(_) + ?PPNewLineBy(_, _)

--- a/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
@@ -250,7 +250,7 @@ rules
       prod -> invalid*
         where
           rhs*     := <get-production-rhs(|chars)> prod;
-          pos*     := <get-production-attrs; collect-all(?Align(<id>) + ?PPAlign(<id>), collapse-lists); not(?[])> prod;
+          pos*     := <get-production-attrs; collect-all(?AlignList(<id>) + ?PPAlignList(<id>), collapse-lists); not(?[])> prod;
           invalid* := <filter(check-non-terminal-symbol(|rhs*))> pos*
 
     check-non-terminal-symbol(|rhs*):

--- a/org.metaborg.meta.lang.template/trans/generation/pp/to-pp.str
+++ b/org.metaborg.meta.lang.template/trans/generation/pp/to-pp.str
@@ -267,7 +267,7 @@ rules
     with
         <reset-counter> "pp";
         line'*           := <map(introduce-labels-line)> line*;
-        lc-selectors*    := <collect-om(?Offside(_, []) <+ ?Align(_) <+ ?PPOffside(_, []) <+ ?PPAlign(_) <+ ?PosRef(_) <+ ?LabelRef(_) <+ ?LiteralRef(_), collapse-lists); strip-annos; nub> a*;
+        lc-selectors*    := <collect-om(?Offside(_, []) <+ ?AlignList(_) <+ ?PPOffside(_, []) <+ ?PPAlignList(_) <+ ?PosRef(_) <+ ?LabelRef(_) <+ ?LiteralRef(_), collapse-lists); strip-annos; nub> a*;
         line''*          := <annotate-lines(|lc-selectors*)> line'*;
         output           := <map(template-line-to-stratego(|lang))> line''*;
         arg*             := <mapconcat(?Line(<filter(placeholder-to-var)>))> line'*;
@@ -297,13 +297,13 @@ rules
   apply-align-layout-constraint(|t, a*):
     SingleLineTemplate(elem*) -> SingleLineTemplate(elem'*)
     where
-      pos-ref* := <collect-all(?Align(<id>) + ?PPAlign(<id>), collapse-lists); not(?[])> a*;
+      pos-ref* := <collect-all(?AlignList(<id>) + ?PPAlignList(<id>), collapse-lists); not(?[])> a*;
       elem'*   := <replace-list-align(|pos-ref*)> (1, elem*)
       
   apply-align-layout-constraint(|t, a*):
     Template(line*) -> Template(line'*)
     where
-      pos-ref* := <collect-all(?Align(<id>) + ?PPAlign(<id>), collapse-lists); not(?[])> a*;
+      pos-ref* := <collect-all(?AlignList(<id>) + ?PPAlignList(<id>), collapse-lists); not(?[])> a*;
       line'*   := <replace-list-align-line(|pos-ref*)> (1, line*)
       
   replace-list-align-line(|pos-ref*):
@@ -539,7 +539,7 @@ rules
     with
       <reset-counter> "pp";
       line'*        := <map(introduce-labels-line)> line*;
-      lc-selectors* := <collect-om(?Align(_) <+ ?Offside(_, []) <+ ?PPAlign(_) <+ ?PPOffside(_, []) <+ ?PosRef(_) <+ ?LabelRef(_) <+ ?LiteralRef(_), collapse-lists); strip-annos; nub> a*;
+      lc-selectors* := <collect-om(?AlignList(_) <+ ?Offside(_, []) <+ ?PPAlignList(_) <+ ?PPOffside(_, []) <+ ?PosRef(_) <+ ?LabelRef(_) <+ ?LiteralRef(_), collapse-lists); strip-annos; nub> a*;
       line''*       := <annotate-lines(|lc-selectors*)> line'*;
       output        := <map(template-line-to-stratego(|lang))> line''*;
       arg*          := <mapconcat(?Line(<filter(placeholder-to-var)>))> line'*;
@@ -578,10 +578,10 @@ rules
     PPAlign(ref, target*) -> NoAnnoList(Op("Align", [ <create-term-from-ref> ref, NoAnnoList(List(<map(create-term-from-ref)> target*))]))
   
   create-constraint-term:
-    Align(ref) -> NoAnnoList(Op("Align", [ <create-term-from-ref> ref]))
+    AlignList(ref) -> NoAnnoList(Op("Align", [ <create-term-from-ref> ref]))
     
   create-constraint-term:
-    PPAlign(ref) -> NoAnnoList(Op("Align", [ <create-term-from-ref> ref]))
+    PPAlignList(ref) -> NoAnnoList(Op("Align", [ <create-term-from-ref> ref]))
   
   create-constraint-term:
     Offside(ref, target*) -> NoAnnoList(Op("Offside", [ <create-term-from-ref> ref, NoAnnoList(List(<map(create-term-from-ref)> target*))]))
@@ -669,10 +669,10 @@ rules
       else
         elem'' := elem'
       end;
-      if align-list-or-offside-constraint := <fetch-elem(?Align(LabelRef(label')) + 
-                                                         ?Align(PosRef(start-pos')) +
-                                                         ?PPAlign(LabelRef(label')) + 
-                                                         ?PPAlign(PosRef(start-pos')) +
+      if align-list-or-offside-constraint := <fetch-elem(?AlignList(LabelRef(label')) + 
+                                                         ?AlignList(PosRef(start-pos')) +
+                                                         ?PPAlignList(LabelRef(label')) + 
+                                                         ?PPAlignList(PosRef(start-pos')) +
                                                          ?Offside(LabelRef(label'), []) +
                                                          ?Offside(PosRef(start-pos'), []) +
                                                          ?PPOffside(LabelRef(label'), []) +

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/LayoutConstraintAttribute.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/LayoutConstraintAttribute.java
@@ -122,7 +122,7 @@ public class LayoutConstraintAttribute implements IAttribute, Serializable {
     }
 
     private int createTree(IStrategoTerm term) throws Exception {
-        if(TermUtils.isAppl(term) && ((IStrategoAppl) term).getName().equals("Tree")) {
+        if(TermUtils.isAppl(term) && ((IStrategoAppl) term).getName().equals("PosRef")) {
             try {
                 return Integer.parseInt(((IStrategoString) term.getSubterm(0)).stringValue());
             } catch(Exception e) {
@@ -205,7 +205,7 @@ public class LayoutConstraintAttribute implements IAttribute, Serializable {
             return tf.makeAppl(tf.makeConstructor("left", 1), toSDF2constraint(c.getSubterm(0), tf));
         } else if(TermUtils.isAppl(c) && ((IStrategoAppl) c).getName().equals("Right")) {
             return tf.makeAppl(tf.makeConstructor("right", 1), toSDF2constraint(c.getSubterm(0), tf));
-        } else if(TermUtils.isAppl(c) && ((IStrategoAppl) c).getName().equals("Tree")) {
+        } else if(TermUtils.isAppl(c) && ((IStrategoAppl) c).getName().equals("PosRef")) {
             String tree = c.getSubterm(0).toString();
             return tf.makeInt(Integer.parseInt(tree.substring(1, tree.length() - 1)));
         } else {


### PR DESCRIPTION
In this PR I have created a new syntax for layout constraints. This new syntax aims at being simpler and easy to use. I have combined the `Constraint` and `ShortConstraint` into one `Constraint`, where low-level constraints and declarations can be used interchangeably. Furthermore, the position referencing in constraints now uses the same references as declarations, which means that it is possible to reference labels, but also positional indeces. This new syntax is also tested. Finally, I have removed some unused code and made the `all` constraint deprecated.

I have not made any changes to the analysis, except for some name changes to reflect the changes in syntax. The next step would be adding more error checking for invalid constraints. I haven't tested the generating of layout constraints, but I believe that will also be broken, which I will fix in a later PR.