### PR TITLE
Feature: layout constraints analysis tests

### DIFF
--- a/org.metaborg.meta.lang.template.test/layout-constraints/analysis.spt
+++ b/org.metaborg.meta.lang.template.test/layout-constraints/analysis.spt
@@ -1,0 +1,63 @@
+module layout-constraints/analysis
+
+language TemplateLang
+
+fixture [[
+module layout-constraints/analysis
+
+context-free syntax
+  A.A = <<l:L*> test { <b:B> } <c:C+>> {layout([[...]])}
+  L.L = "L"
+  B.B = "B"
+  C.C = "C"
+]]
+
+test offside label one [[offside b]] analysis succeeds
+test offside index one [[offside 3]] analysis succeeds
+test offside index terminal [[offside [[1]] ]] 1 error at #1
+test offside label more [[offside l b, c]] analysis succeeds
+test offside index more [[offside 1 2, 4]] analysis succeeds
+test offside mixed ref more [[offside b 4, c]] analysis succeeds
+test offside before invalid [[offside c b]] analysis fails
+test offside same [[offside b 3]] analysis fails
+test offside list not in order [[offside 1 c, b]] analysis succeeds
+test offside out of bounds index [[offside [[7]] [[8]],[[9]] ]] 3 error at #1, #2, #3
+test offside invalid label [[offside [[f]] [[g]] ]] 2 errors at #1, #2
+
+test indent label one [[indent b c]] analysis succeeds
+test indent index one [[indent 1 2]] analysis succeeds
+test indent label index [[indent b 5]] analysis succeeds
+test indent index label [[indent 2 b]] analysis succeeds
+test indent more [[indent l 1, b, 4, c]] analysis succeeds
+test indent same [[indent b 3]] analysis fails
+test indent out of bounds index [[indent b [[6]] ]] 1 error at #1
+test indent invalid label [[indent b [[d]] ]] 1 error at #1
+
+test align label one [[align b c]] analysis succeeds
+test align index one [[align 2 3]] analysis succeeds
+test align label index [[align b 4]] analysis succeeds
+test align index label [[align 1 b]] analysis succeeds
+test align mixed more [[align l 1, 2, b, 4, c]] analysis succeeds
+test align same [[align b 3, b]] analysis fails
+test align out of bounds index [[align c [[6]] ]] 1 error at #1
+test align invalid label [[align [[d]] 3]] 1 error at #1
+
+test align list label zero or more [[align-list l]] analysis succeeds
+test align list label one or more [[align-list c]] analysis succeeds
+test align list index zero or more [[align-list 0]] analysis succeeds
+test align list index one or more [[align-list 5]] analysis succeeds
+test align list label invalid non-terminal [[align-list [[b]] ]] 1 error at #1
+test align list index invalid non-terminal [[align-list [[3]] ]] 1 error at #1
+test align list index invalid terminal [[align-list [[1]] ]] 1 error at #1
+test align list out of bounds index [[align-list [[6]] ]] 1 error at #1
+test align list invalid label [[align-list [[z]] ]] 1 error at #1
+
+test newline indent label one [[newline-indent b c]] analysis succeeds
+test newline indent index one [[newline-indent 1 2]] analysis succeeds
+test newline indent label more [[newline-indent l b, c]] analysis succeeds
+test newline indent index more [[newline-indent 1 2, 4]] analysis succeeds
+test newline indent mixed [[newline-indent 1 b, 4, c]] analysis succeeds
+test newline indent same [[newline-indent b 3]] analysis fails
+test newline indent wrong order [[newline-indent c b]] analysis fails
+test newline indent out of bounds index [[newline-indent b [[7]], [[8]] ]] 2 errors at #1, #2
+test newline indent invalid label [[newline-indent [[d]] [[z]] ]] 2 errors at #1, #2

--- a/org.metaborg.meta.lang.template.test/layout-constraints/analysis.spt
+++ b/org.metaborg.meta.lang.template.test/layout-constraints/analysis.spt
@@ -27,9 +27,9 @@ test offside index one [[offside 3]] analysis succeeds
 test offside index terminal [[offside [[1]] ]] 1 error at #1
 test offside label more [[offside l b, c]] analysis succeeds
 test offside index more [[offside 1 2, 4]] analysis succeeds
-test offside mixed ref more [[offside b 4, c]] analysis succeeds
-test offside before invalid [[offside c b]] analysis fails
-test offside same [[offside b [[3]], 1, [["test"]] ]] 2 errors at #1, #2
+test offside mixed ref more [[offside b c, 4]] analysis succeeds
+test offside before invalid [[offside c [[b]], [[1]] ]] 2 errors at #1, #2
+test offside same [[offside b [[3]], c, [[5]] ]] 2 errors at #1, #2
 test offside list not in order [[offside 1 c, b]] analysis succeeds
 test offside out of bounds index [[offside [[7]] [[8]],[[9]] ]] 3 errors at #1, #2, #3
 test offside invalid label [[offside [[f]] [[g]] ]] 2 errors at #1, #2
@@ -40,6 +40,7 @@ test indent label index [[indent b 5]] analysis succeeds
 test indent index label [[indent 2 b]] analysis succeeds
 test indent more [[indent l 1, b, 4, c]] analysis succeeds
 test indent same [[indent b 3]] analysis fails
+test indent out of order [[indent c b]] analysis succeeds
 test indent out of bounds index [[indent b [[6]] ]] 1 error at #1
 test indent invalid label [[indent b [[d]] ]] 1 error at #1
 
@@ -49,6 +50,7 @@ test align label index [[align b 4]] analysis succeeds
 test align index label [[align 1 b]] analysis succeeds
 test align mixed more [[align l 1, 2, b, 4, c]] analysis succeeds
 test align same [[align b 3, b]] analysis fails
+test align out of order [[align c b]] analysis succeeds
 test align out of bounds index [[align c [[6]] ]] 1 error at #1
 test align invalid label [[align [[d]] 3]] 1 error at #1
 
@@ -70,7 +72,7 @@ test newline indent index more [[newline-indent 1 2, 4]] analysis succeeds
 test newline indent literal label [[newline-indent "test" b]] analysis succeeds
 test newline indent mixed [[newline-indent 1 b, 4, c]] analysis succeeds
 test newline indent same [[newline-indent b 3]] analysis fails
-test newline indent wrong order [[newline-indent c b]] analysis fails
+test newline indent out of order [[newline-indent c [[b]], [[4]] ]] 2 errors at #1, #2
 test newline indent undefined literal [[newline-indent [["["]] c]] 1 error at #1
 test newline indent duplicate literal [[newline-indent [["-"]] c]] 1 error at #1
 test newline indent out of bounds index [[newline-indent b [[7]], [[8]] ]] 2 errors at #1, #2

--- a/org.metaborg.meta.lang.template.test/layout-constraints/analysis.spt
+++ b/org.metaborg.meta.lang.template.test/layout-constraints/analysis.spt
@@ -6,7 +6,7 @@ fixture [[
 module layout-constraints/analysis
 
 context-free syntax
-  A.A = <<l:L*> test { <b:B> } <c:C+>> {layout([[...]])}
+  A.A = <<l:L*> test - <b:B> - <c:C+>> {layout([[...]])}
   L.L = "L"
   B.B = "B"
   C.C = "C"
@@ -46,6 +46,7 @@ test align list label zero or more [[align-list l]] analysis succeeds
 test align list label one or more [[align-list c]] analysis succeeds
 test align list index zero or more [[align-list 0]] analysis succeeds
 test align list index one or more [[align-list 5]] analysis succeeds
+test align list literal [[align-list [["test"]] ]] 1 error at #1
 test align list label invalid non-terminal [[align-list [[b]] ]] 1 error at #1
 test align list index invalid non-terminal [[align-list [[3]] ]] 1 error at #1
 test align list index invalid terminal [[align-list [[1]] ]] 1 error at #1
@@ -56,8 +57,11 @@ test newline indent label one [[newline-indent b c]] analysis succeeds
 test newline indent index one [[newline-indent 1 2]] analysis succeeds
 test newline indent label more [[newline-indent l b, c]] analysis succeeds
 test newline indent index more [[newline-indent 1 2, 4]] analysis succeeds
+test newline indent literal label [[newline-indent "test" b]] analysis succeeds
 test newline indent mixed [[newline-indent 1 b, 4, c]] analysis succeeds
 test newline indent same [[newline-indent b 3]] analysis fails
 test newline indent wrong order [[newline-indent c b]] analysis fails
+test newline indent undefined literal [[newline-indent [["["]] c]] 1 error at #1
+test newline indent duplicate literal [[newline-indent [["-"]] c]] 1 error at #1
 test newline indent out of bounds index [[newline-indent b [[7]], [[8]] ]] 2 errors at #1, #2
 test newline indent invalid label [[newline-indent [[d]] [[z]] ]] 2 errors at #1, #2

--- a/org.metaborg.meta.lang.template.test/layout-constraints/analysis.spt
+++ b/org.metaborg.meta.lang.template.test/layout-constraints/analysis.spt
@@ -12,6 +12,16 @@ context-free syntax
   C.C = "C"
 ]]
 
+
+test constraint num [[1 == 1]] analysis fails
+test constraint index num [[1.first.line == 0]] analysis succeeds
+test constraint label num [[b.first.line == 0]] analysis succeeds
+test constraint index [[1.first.line == 5.last.line]] analysis succeeds
+test constraint label [[l.first.line == b.last.line]] analysis succeeds
+test constraint literal [["test".first.line == "test".last.line]] analysis succeeds
+test constraint out of bounds index [[7.first.col == 0]] analysis fails
+test constraint dupblicate literal [["-".first.col == "-".first.col]] analysis fails
+
 test offside label one [[offside b]] analysis succeeds
 test offside index one [[offside 3]] analysis succeeds
 test offside index terminal [[offside [[1]] ]] 1 error at #1

--- a/org.metaborg.meta.lang.template.test/layout-constraints/analysis.spt
+++ b/org.metaborg.meta.lang.template.test/layout-constraints/analysis.spt
@@ -19,9 +19,9 @@ test offside label more [[offside l b, c]] analysis succeeds
 test offside index more [[offside 1 2, 4]] analysis succeeds
 test offside mixed ref more [[offside b 4, c]] analysis succeeds
 test offside before invalid [[offside c b]] analysis fails
-test offside same [[offside b 3]] analysis fails
+test offside same [[offside b [[3]], 1, [["test"]] ]] 2 errors at #1, #2
 test offside list not in order [[offside 1 c, b]] analysis succeeds
-test offside out of bounds index [[offside [[7]] [[8]],[[9]] ]] 3 error at #1, #2, #3
+test offside out of bounds index [[offside [[7]] [[8]],[[9]] ]] 3 errors at #1, #2, #3
 test offside invalid label [[offside [[f]] [[g]] ]] 2 errors at #1, #2
 
 test indent label one [[indent b c]] analysis succeeds

--- a/org.metaborg.meta.lang.template.test/layout-constraints/analysis.spt
+++ b/org.metaborg.meta.lang.template.test/layout-constraints/analysis.spt
@@ -13,7 +13,12 @@ context-free syntax
 ]]
 
 
-test constraint num [[1 == 1]] analysis fails
+test constraint irrelevant eq [[ [[1 == 1]] ]] 1 warning at #1
+test constraint irrelevant lt [[ [[1 + 1 < 1]] ]] 1 warning at #1
+test constraint irrelevant le [[ [[1 - 2 <= 1]] ]] 1 warning at #1
+test constraint irrelevant gt [[ [[1 > 1 * 4]] ]] 1 warning at #1
+test constraint irrelevant ge [[ [[1 >= 2 / 1]] ]] 1 warning at #1
+
 test constraint index num [[1.first.line == 0]] analysis succeeds
 test constraint label num [[b.first.line == 0]] analysis succeeds
 test constraint index [[1.first.line == 5.last.line]] analysis succeeds

--- a/org.metaborg.meta.lang.template/trans/analysis/desugar.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/desugar.str
@@ -323,7 +323,7 @@ rules
       constraint := <map(get-tree-position(|rhs*); create-align-constraint(|ref-pos')); flatten-list; combine-constraints> pos*
 
   get-tree-position(|rhs*):
-    PosRef(p) -> PosRef(<dec> p)
+    PosRef(p) -> PosRef(p)
 
   get-tree-position(|rhs*):
     LiteralRef(l) -> PosRef(<dec; int-to-string> p)

--- a/org.metaborg.meta.lang.template/trans/analysis/desugar.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/desugar.str
@@ -339,10 +339,10 @@ rules
       p := <get-index> (Label(Unquoted(l'), symbol), rhs'*)
 
   get-non-terminal-symbol(|rhs*):
-    PosRef(p) -> <index; ?Label(_, <id>)> (<string-to-int> p, rhs*)
+    PosRef(p) -> <index; ?Label(_, <id>)> (<string-to-int; inc> p, rhs*)
 
   get-non-terminal-symbol(|rhs*):
-    PosRef(p) -> <index> (<string-to-int> p, rhs*)
+    PosRef(p) -> <index> (<string-to-int; inc> p, rhs*)
 
   get-non-terminal-symbol(|rhs*):
     LabelRef(l) -> symbol

--- a/org.metaborg.meta.lang.template/trans/analysis/desugar.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/desugar.str
@@ -216,14 +216,14 @@ rules
   create-productions-align-list(|chars):
     SdfProduction(lhs, Rhs(rhs*), Attrs(attrs*)) -> prods*
     where
-      pos*           := <collect-all(?AlignList(<id>), collapse-lists); not(?[])> attrs*;
+      pos*           := <collect-all(?AlignList(<id>), conc); not(?[])> attrs*;
       non-terminals* := <map(get-non-terminal-symbol(|rhs*))> pos*;
       prods*         := <filter(generate-align-productions)> non-terminals*
 
   create-productions-align-list(|chars):
     SdfProductionWithCons(lhs, Rhs(rhs*), Attrs(attrs*)) -> prods*
     where
-      pos*           := <collect-all(?AlignList(<id>), collapse-lists); not(?[])> attrs*;
+      pos*           := <collect-all(?AlignList(<id>), conc); not(?[])> attrs*;
       non-terminals* := <map(get-non-terminal-symbol(|rhs*))> pos*;
       prods*         := <filter(generate-align-productions)> non-terminals*
 
@@ -231,7 +231,7 @@ rules
     t@TemplateProduction(lhs, rhs, Attrs(attrs*)) -> prods*
     where
       rhs*           := <get-production-rhs(|chars)> t;
-      pos*           := <collect-all(?AlignList(<id>), collapse-lists); not(?[])> attrs*;
+      pos*           := <collect-all(?AlignList(<id>), conc); not(?[])> attrs*;
       non-terminals* := <map(get-non-terminal-symbol(|rhs*))> pos*;
       prods*         := <filter(generate-align-productions)> non-terminals*
 
@@ -239,7 +239,7 @@ rules
     t@TemplateProductionWithCons(lhs, rhs, Attrs(attrs*)) -> prods*
     where
       rhs*           := <get-production-rhs(|chars)> t;
-      pos*           := <collect-all(?AlignList(<id>), collapse-lists); not(?[])> attrs*;
+      pos*           := <collect-all(?AlignList(<id>), conc); not(?[])> attrs*;
       non-terminals* := <map(get-non-terminal-symbol(|rhs*))> pos*;
       prods*         := <filter(generate-align-productions)> non-terminals*
 

--- a/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
@@ -174,9 +174,12 @@ rules
       positions*  := <filter(check-for-pos-ref(|chars)); flatten-list> prods*;
       literals*   := <filter(check-for-literals(|chars)); flatten-list> prods*;
       align-list* := <filter(check-align-list(|chars)); flatten-list> prods*;
+      offside*    := <filter(check-offside(|chars)); flatten-list> prods*;
       <map(task-create-error(|ctx, $[Invalid tree selector - index ouf of bounds]))> positions*;
       <map(task-create-error(|ctx, $[Invalid tree selector - undefined or duplicated literal]))> literals*;
-      <map(task-create-error(|ctx, $[Invalid tree selector - align-list should be applied to list non-terminal]))> align-list*
+      <map(task-create-error(|ctx, $[Invalid tree selector - align-list should be applied to list non-terminal]))> align-list*;
+      <map(task-create-error(|ctx, $[Invalid tree selector - offside with single argument should be applied to non-terminal]))> offside*
+
 
     check-for-pos-ref(|chars) :
         prod -> invalid*
@@ -251,12 +254,22 @@ rules
         where
           rhs*     := <get-production-rhs(|chars)> prod;
           pos*     := <get-production-attrs; collect-all(?AlignList(<id>) + ?PPAlignList(<id>), collapse-lists); not(?[])> prod;
-          invalid* := <filter(check-non-terminal-symbol(|rhs*))> pos*
+          invalid* := <filter-invalid-pos(not-iter|rhs*)> pos*
 
-    check-non-terminal-symbol(|rhs*):
-      pos -> <id>
-      where
-        <get-non-terminal-symbol(|rhs*); not(?Iter(_) <+ ?IterStar(_) <+ ?IterSep(_, _) <+ ?IterStarSep(_, _)) > pos
+    not-iter = not(?Iter(_) <+ ?IterStar(_) <+ ?IterSep(_, _) <+ ?IterStarSep(_, _))
+
+    check-offside(|chars):
+      prod -> invalid*
+        where
+          rhs*     := <get-production-rhs(|chars)> prod;
+          pos*     := <get-production-attrs; collect-all(offside-to-argument, conc); not(?[])> prod;
+          invalid* := <filter-invalid-pos(?Lit(_)|rhs*)> pos*
+
+    offside-to-argument: Offside(p, []) -> p
+    offside-to-argument: PPOffside(p, []) -> p
+
+    filter-invalid-pos(invalid|rhs*) = filter(where(get-non-terminal-symbol(|rhs*); invalid))
+
 
     nabl-constraint(|lang, ctx, uri*):
       String(s) -> <fail>

--- a/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
@@ -165,161 +165,130 @@ rules
         seq* := <collect(?Lex(_) <+ ?Cf(_) <+ ?Sequence(_,_)); filter(?Sequence(_,_))> p
 
 
-
-    nabl-constraint(|ctx):
-      Module(Unparameterized(m), i*, s*) -> <fail>
+/********************
+ * Layout Constraints
+ ********************/
+rules
+  nabl-constraint(|ctx): Module(Unparameterized(_), _, s) -> <fail>
     where
-      chars       := <collect-one(?Tokenize(<id; explode-string; un-double-quote-chars>)) <+ !['(', ')']> s*;
-      prods*      := <filter(?SDFSection(ContextFreeSyntax(<id>)) <+ ?SDFSection(Kernel(<id>))); flatten-list> s*;
-      positions*  := <filter(check-for-pos-ref(|chars)); flatten-list> prods*;
-      literals*   := <filter(check-for-literals(|chars)); flatten-list> prods*;
-      align-list* := <filter(check-align-list(|chars)); flatten-list> prods*;
-      offside*    := <filter(check-offside(|chars)); flatten-list> prods*;
-      duplicate*  := <filter(check-duplicate(|chars)); flatten-list> prods*;
-      order*      := <filter(check-order(|chars)); flatten-list> prods*;
-      <map(task-create-error(|ctx, $[Invalid tree selector - index ouf of bounds]))> positions*;
-      <map(task-create-error(|ctx, $[Invalid tree selector - undefined or duplicated literal]))> literals*;
-      <map(task-create-error(|ctx, $[Invalid tree selector - align-list should be applied to list non-terminal]))> align-list*;
-      <map(task-create-error(|ctx, $[Invalid tree selector - offside with single argument should be applied to non-terminal]))> offside*;
-      <map(task-create-error(|ctx, $[Invalid tree selector - declaration cannot be applied to the same tree]))> duplicate*;
-      <map(task-create-error(|ctx, $[Invalid tree selector - All arguments should come after the first argument]))> order*
+      chars := <collect-one(?Tokenize(<id; explode-string; un-double-quote-chars>)) <+ !['(', ')']> s;
+      prods := <filter(?SDFSection(ContextFreeSyntax(<id>)) <+ ?SDFSection(Kernel(<id>))); flatten-list> s;
+      <filter(check-layout-constraints(|ctx, chars))> prods
 
+  create-errors(|ctx): (errors, msg) -> <map(task-create-error(|ctx, msg))> errors
 
-    check-for-pos-ref(|chars) :
-        prod -> invalid*
-        where
-          posRef*  := <collect-all(?PosRef(<id>), collapse-lists)> prod;
-          invalid* := <filter(is-invalid-pos(|prod, chars))> posRef*
-
-    is-invalid-pos(|p, chars) :
-        position -> <id>
-        where
-          intPos := <string-to-int> position;
-          <gt> (intPos, <production-arity(|chars); dec> p)
-
-    production-arity(|chars) :
-      SdfProduction(_, Rhs(rhs*), _) -> <length> rhs*
-
-    production-arity(|chars) :
-      SdfProductionWithCons(_, Rhs(rhs*), _) -> <length> rhs*
-
-    production-arity(|chars) :
-      t@TemplateProduction(_, _, _) -> <desugar-templates; template-to-sdf3-prod(|chars); production-arity(|chars)> t
-
-    production-arity(|chars) :
-      t@TemplateProductionWithCons(_, _, _) -> <desugar-templates; template-to-sdf3-prod(|chars); production-arity(|chars)> t
-
-    collapse-lists:
-      (l1*, l2*) -> [l1*, l2*]
-
-    check-for-literals(|chars) :
-        prod -> invalid*
+  check-layout-constraints(|ctx, chars): prod -> <id>
     where
-       litRef* := <collect-all(?LiteralRef(<id>), collapse-lists)> prod;
-       invalid* := <filter(is-invalid-lit(|prod, chars))> litRef*
-
-    is-invalid-lit(|prod, chars):
-      lit -> <id>
-      where
-        literal := Lit(lit);
-        <not(get-production-rhs(|chars); is-defined-not-duplicated-literal(|literal))> prod
-
-    get-production-rhs(|chars):
-      SdfProduction(_, Rhs(rhs*), _) -> rhs*
-
-    get-production-rhs(|chars):
-      SdfProductionWithCons(_, Rhs(rhs*), _) -> rhs*
-
-    get-production-rhs(|chars):
-      t@TemplateProduction(_, _, _) -> <desugar-templates; template-to-sdf3-prod(|chars); get-production-rhs(|chars)> t
-
-    get-production-rhs(|chars):
-      t@TemplateProductionWithCons(_, _, _) -> <desugar-templates; template-to-sdf3-prod(|chars); get-production-rhs(|chars)> t
-
-    get-production-attrs:
-      SdfProduction(_, _, Attrs(attrs*)) -> attrs*
-
-    get-production-attrs:
-      SdfProductionWithCons(_, _, Attrs(attrs*)) -> attrs*
-
-    get-production-attrs:
-      TemplateProduction(_, _, Attrs(attrs*)) -> attrs*
-
-    get-production-attrs:
-      TemplateProductionWithCons(_, _, Attrs(attrs*)) -> attrs*
-
-    is-defined-not-duplicated-literal(|lit):
-      rhs* ->  <eq> (1, <length> rhs'*)
-        where
-          rhs'* := <filter(?lit)> rhs*
-
-    check-align-list(|chars):
-      prod -> invalid*
-        where
-          rhs*     := <get-production-rhs(|chars)> prod;
-          pos*     := <get-production-attrs; collect-all(?AlignList(<id>) + ?PPAlignList(<id>), collapse-lists); not(?[])> prod;
-          invalid* := <filter-invalid-pos(not-iter|rhs*)> pos*
-
-    not-iter = not(?Iter(_) <+ ?IterStar(_) <+ ?IterSep(_, _) <+ ?IterStarSep(_, _))
-
-    check-offside(|chars):
-      prod -> invalid*
-        where
-          rhs*     := <get-production-rhs(|chars)> prod;
-          pos*     := <get-production-attrs; collect-all(offside-to-argument, conc); not(?[])> prod;
-          invalid* := <filter-invalid-pos(?Lit(_)|rhs*)> pos*
-
-    offside-to-argument: Offside(p, []) -> p
-    offside-to-argument: PPOffside(p, []) -> p
-
-    filter-invalid-pos(invalid|rhs*) = filter(where(get-non-terminal-symbol(|rhs*); invalid))
-
-    check-duplicate(|chars):
-      prod -> invalid*
-        where
-          rhs* := <get-production-rhs(|chars)> prod;
-          pos* := <get-production-attrs; collect-all(decls-to-arguments, collapse-lists); not(?[])> prod;
-          invalid* := <map(get-duplicate-pos(|rhs*)); flatten-list> pos*
-
-    decls-to-arguments: Offside(p, ps) -> [p | ps] where <not(?[])> ps
-    decls-to-arguments: Indent(p, ps) -> [p | ps] where <not(?[])> ps
-    decls-to-arguments: Align(p, ps) -> [p | ps] where <not(?[])> ps
-    decls-to-arguments: NewLineIndent(p, ps) -> [p | ps] where <not(?[])> ps
-
-    get-duplicate-pos(|rhs*):
-      pos* -> dups
-        where
-          (_, dups) := <foldl(fold-duplicate-tree(|rhs*))> (pos*, ([],[]))
-
-    fold-duplicate-tree(|rhs*) =
-      ?(pos, (set, dups));
-      tree := <get-tree-position(|rhs*)> pos;
-      if <member> (tree, set) then
-        !(set,[pos|dups])
-      else
-        !([tree|set],dups)
-      end
-
-    check-order(|chars):
-      prod -> invalid*
-        where
-          rhs* := <get-production-rhs(|chars)> prod;
-          pos* := <get-production-attrs; collect-all(decls-to-pair, collapse-lists); not(?[])> prod;
-          invalid* := <map(get-out-of-order(|rhs*)); flatten-list> pos*
-
-    get-out-of-order(|rhs*): (refpos, pos*) -> <filter(is-out-of-order(|rhs*, ref))> pos*
-      where
-        PosRef(ref) := <get-tree-position(|rhs*)> refpos
-
-    is-out-of-order(|rhs*, ref): pos -> <id>
-      where
-        PosRef(tree) := <get-tree-position(|rhs*)> pos;
-        <ltS> (tree, ref)
-
-    decls-to-pair: Offside(p, ps) -> (p, ps) where <not(?[])> ps
-    decls-to-pair: NewLineIndent(p, ps) -> (p, ps) where <not(?[])> ps
+      rhs := <get-production-rhs(|chars)> prod;
+      attrs := <get-production-attrs> prod;
+      <try(check-for-pos-ref; create-errors(|ctx))> (rhs, attrs);
+      <try(check-for-literals; create-errors(|ctx))> (rhs, attrs);
+      <try(check-align-list; create-errors(|ctx))> (rhs, attrs);
+      <try(check-offside; create-errors(|ctx))> (rhs, attrs);
+      <try(check-duplicate; create-errors(|ctx))> (rhs, attrs);
+      <try(check-order; create-errors(|ctx))> (rhs, attrs)
 
 
+  get-production-rhs(|chars): SdfProduction(_, Rhs(rhs), _) -> rhs
+  get-production-rhs(|chars): SdfProductionWithCons(_, Rhs(rhs), _) -> rhs
+  get-production-rhs(|chars):
+    t@TemplateProduction(_, _, _) -> <desugar-templates; template-to-sdf3-prod(|chars); get-production-rhs(|chars)> t
+  get-production-rhs(|chars):
+    t@TemplateProductionWithCons(_, _, _) -> <desugar-templates; template-to-sdf3-prod(|chars); get-production-rhs(|chars)> t
+
+  get-production-attrs: SdfProduction(_, _, Attrs(attrs)) -> attrs
+  get-production-attrs: SdfProductionWithCons(_, _, Attrs(attrs)) -> attrs
+  get-production-attrs: TemplateProduction(_, _, Attrs(attrs)) -> attrs
+  get-production-attrs: TemplateProductionWithCons(_, _, Attrs(attrs)) -> attrs
+
+
+  check-for-pos-ref: (rhs, attrs) -> (invalids, "Invalid tree selector - index ouf of bounds")
+    where
+      posRefs := <collect-all(?PosRef(<id>), conc)> attrs;
+      invalids := <filter(is-invalid-pos(|rhs))> posRefs
+
+  is-invalid-pos(|rhs): pos -> <id>
+    where
+      <gt> (<string-to-int> pos, <length; dec> rhs)
+
+
+  check-for-literals: (rhs, attrs) -> (invalids, "Invalid tree selector - undefined or duplicated literal")
+    where
+      litRefs := <collect-all(?LiteralRef(<id>), conc)> attrs;
+      invalids := <filter(is-invalid-lit(|rhs))> litRefs
+
+  is-invalid-lit(|rhs): lit -> <id>
+    where
+      <not(eq)> (1, <filter(?Lit(lit)); length> rhs)
+
+
+  check-align-list: (rhs, attrs) -> (invalids, "Invalid tree selector - align-list should be applied to list non-terminal")
+    where
+      positions := <collect-all(?AlignList(<id>) + ?PPAlignList(<id>), conc); not(?[])> attrs;
+      invalids := <filter-invalid-pos(not-iter|rhs)> positions
+
+  not-iter = not(?Iter(_) <+ ?IterStar(_) <+ ?IterSep(_, _) <+ ?IterStarSep(_, _))
+
+
+  check-offside: (rhs, attrs) -> (invalids, "Invalid tree selector - offside with single argument should be applied to non-terminal")
+    where
+      positions := <collect-all(?Offside(<id>, []) + ?PPOffside(<id>, []), conc); not(?[])> attrs;
+      invalids := <filter-invalid-pos(?Lit(_)|rhs)> positions
+
+
+  filter-invalid-pos(invalid|rhs) = filter(where(get-non-terminal-symbol(|rhs); invalid))
+
+
+  check-duplicate: (rhs, attrs) -> (invalids, "Invalid tree selector - declaration cannot be applied to the same tree")
+    where
+      positions := <collect-all(decls-to-arguments, conc); not(?[])> attrs;
+      invalids := <map(get-duplicate-pos(|rhs)); flatten-list> positions
+
+  decls-to-arguments: Offside(p, ps) -> [p | ps] where <not(?[])> ps
+  decls-to-arguments: PPOffside(p, ps) -> [p | ps] where <not(?[])> ps
+  decls-to-arguments: Indent(p, ps) -> [p | ps] where <not(?[])> ps
+  decls-to-arguments: PPIndent(p, ps) -> [p | ps] where <not(?[])> ps
+  decls-to-arguments: Align(p, ps) -> [p | ps] where <not(?[])> ps
+  decls-to-arguments: PPAlign(p, ps) -> [p | ps] where <not(?[])> ps
+  decls-to-arguments: NewLineIndent(p, ps) -> [p | ps] where <not(?[])> ps
+  decls-to-arguments: PPNewLineIndent(p, ps) -> [p | ps] where <not(?[])> ps
+  decls-to-arguments: PPNewLineIndentBy(_, p, ps) -> [p | ps] where <not(?[])> ps
+
+  get-duplicate-pos(|rhs): positions -> dups
+    where
+      (_, dups) := <foldl(fold-duplicate-tree(|rhs))> (positions, ([],[]))
+
+  fold-duplicate-tree(|rhs) =
+    ?(pos, (set, dups));
+    tree := <get-tree-position(|rhs)> pos;
+    if <member> (tree, set) then
+      !(set, [pos|dups])
+    else
+      !([tree|set], dups)
+    end
+
+
+  check-order: (rhs, attrs) -> (invalids, "Invalid tree selector - All arguments should come after the first argument")
+    where
+      positions := <collect-all(decls-to-pair, conc); not(?[])> attrs;
+      invalids := <map(get-out-of-order(|rhs)); flatten-list> positions
+
+  decls-to-pair: Offside(p, ps) -> (p, ps) where <not(?[])> ps
+  decls-to-pair: PPOffside(p, ps) -> (p, ps) where <not(?[])> ps
+  decls-to-pair: NewLineIndent(p, ps) -> (p, ps) where <not(?[])> ps
+  decls-to-pair: PPNewLineIndent(p, ps) -> (p, ps) where <not(?[])> ps
+  decls-to-pair: PPNewLineIndentBy(_, p, ps) -> (p, ps) where <not(?[])> ps
+
+  get-out-of-order(|rhs): (ref, positions) -> <filter(where(is-out-of-order(|rhs, posRef)))> positions
+    where
+      PosRef(posRef) := <get-tree-position(|rhs)> ref
+
+  is-out-of-order(|rhs, ref): pos -> <ltS> (tree, ref)
+    where
+      PosRef(tree) := <get-tree-position(|rhs)> pos
+
+
+rules
     nabl-constraint(|lang, ctx, uri*):
       String(s) -> <fail>
     where
@@ -356,7 +325,6 @@ rules
         cons-types := <type-lookup(|ctx)> lookup;
         same-types := <task-create-rewrite(|ctx, "match-sort-type")> (type, cons-types);
         <task-create-warning-on-triggers(|ctx, [Multiple(same-types)], $[Duplicated definition for constructor [c]: the generated pretty-printer might not work properly])> c
-
 
   prod-without-constructor:
         p@SdfProduction(SortDef(s), Rhs(prod-sorts), Attrs(attrs*)) -> s

--- a/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
@@ -176,7 +176,7 @@ rules
       align-list* := <filter(check-align-list(|chars)); flatten-list> prods*;
       <map(task-create-error(|ctx, $[Invalid tree selector - index ouf of bounds]))> positions*;
       <map(task-create-error(|ctx, $[Invalid tree selector - undefined or duplicated literal]))> literals*;
-      <map(task-create-error(|ctx, $[Invalid tree selector - unary align should be applied to list non-terminal]))> align-list*
+      <map(task-create-error(|ctx, $[Invalid tree selector - align-list should be applied to list non-terminal]))> align-list*
 
     check-for-pos-ref(|chars) :
         prod -> invalid*

--- a/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
@@ -175,10 +175,12 @@ rules
       literals*   := <filter(check-for-literals(|chars)); flatten-list> prods*;
       align-list* := <filter(check-align-list(|chars)); flatten-list> prods*;
       offside*    := <filter(check-offside(|chars)); flatten-list> prods*;
+      duplicate*  := <filter(check-duplicate(|chars)); flatten-list> prods*;
       <map(task-create-error(|ctx, $[Invalid tree selector - index ouf of bounds]))> positions*;
       <map(task-create-error(|ctx, $[Invalid tree selector - undefined or duplicated literal]))> literals*;
       <map(task-create-error(|ctx, $[Invalid tree selector - align-list should be applied to list non-terminal]))> align-list*;
-      <map(task-create-error(|ctx, $[Invalid tree selector - offside with single argument should be applied to non-terminal]))> offside*
+      <map(task-create-error(|ctx, $[Invalid tree selector - offside with single argument should be applied to non-terminal]))> offside*;
+      <map(task-create-error(|ctx, $[Invalid tree selector - declaration cannot be applied to the same tree]))> duplicate*
 
 
     check-for-pos-ref(|chars) :
@@ -269,6 +271,32 @@ rules
     offside-to-argument: PPOffside(p, []) -> p
 
     filter-invalid-pos(invalid|rhs*) = filter(where(get-non-terminal-symbol(|rhs*); invalid))
+
+    check-duplicate(|chars):
+      prod -> invalid*
+        where
+          rhs* := <get-production-rhs(|chars)> prod;
+          pos* := <get-production-attrs; collect-all(decls-to-arguments, collapse-lists); not(?[])> prod;
+          invalid* := <map(get-duplicate-pos(|rhs*)); flatten-list> pos*
+
+    decls-to-arguments: Offside(p, ps) -> [p | ps] where <not(?[])> ps
+    decls-to-arguments: Indent(p, ps) -> [p | ps] where <not(?[])> ps
+    decls-to-arguments: Align(p, ps) -> [p | ps] where <not(?[])> ps
+    decls-to-arguments: NewLineIndent(p, ps) -> [p | ps] where <not(?[])> ps
+
+    get-duplicate-pos(|rhs*):
+      pos* -> dups
+        where
+          (_, dups) := <foldl(fold-duplicate-tree(|rhs*))> (pos*, ([],[]))
+
+    fold-duplicate-tree(|rhs*) =
+      ?(pos, (set, dups));
+      tree := <get-tree-position(|rhs*)> pos;
+      if <member> (tree, set) then
+        !(set,[pos|dups])
+      else
+        !([tree|set],dups)
+      end
 
 
     nabl-constraint(|lang, ctx, uri*):

--- a/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
@@ -176,11 +176,13 @@ rules
       align-list* := <filter(check-align-list(|chars)); flatten-list> prods*;
       offside*    := <filter(check-offside(|chars)); flatten-list> prods*;
       duplicate*  := <filter(check-duplicate(|chars)); flatten-list> prods*;
+      order*      := <filter(check-order(|chars)); flatten-list> prods*;
       <map(task-create-error(|ctx, $[Invalid tree selector - index ouf of bounds]))> positions*;
       <map(task-create-error(|ctx, $[Invalid tree selector - undefined or duplicated literal]))> literals*;
       <map(task-create-error(|ctx, $[Invalid tree selector - align-list should be applied to list non-terminal]))> align-list*;
       <map(task-create-error(|ctx, $[Invalid tree selector - offside with single argument should be applied to non-terminal]))> offside*;
-      <map(task-create-error(|ctx, $[Invalid tree selector - declaration cannot be applied to the same tree]))> duplicate*
+      <map(task-create-error(|ctx, $[Invalid tree selector - declaration cannot be applied to the same tree]))> duplicate*;
+      <map(task-create-error(|ctx, $[Invalid tree selector - All arguments should come after the first argument]))> order*
 
 
     check-for-pos-ref(|chars) :
@@ -297,6 +299,25 @@ rules
       else
         !([tree|set],dups)
       end
+
+    check-order(|chars):
+      prod -> invalid*
+        where
+          rhs* := <get-production-rhs(|chars)> prod;
+          pos* := <get-production-attrs; collect-all(decls-to-pair, collapse-lists); not(?[])> prod;
+          invalid* := <map(get-out-of-order(|rhs*)); flatten-list> pos*
+
+    get-out-of-order(|rhs*): (refpos, pos*) -> <filter(is-out-of-order(|rhs*, ref))> pos*
+      where
+        PosRef(ref) := <get-tree-position(|rhs*)> refpos
+
+    is-out-of-order(|rhs*, ref): pos -> <id>
+      where
+        PosRef(tree) := <get-tree-position(|rhs*)> pos;
+        <ltS> (tree, ref)
+
+    decls-to-pair: Offside(p, ps) -> (p, ps) where <not(?[])> ps
+    decls-to-pair: NewLineIndent(p, ps) -> (p, ps) where <not(?[])> ps
 
 
     nabl-constraint(|lang, ctx, uri*):

--- a/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
@@ -176,6 +176,7 @@ rules
       <filter(check-layout-constraints(|ctx, chars))> prods
 
   create-errors(|ctx): (errors, msg) -> <map(task-create-error(|ctx, msg))> errors
+  create-warnings(|ctx): (warnings, msg) -> <map(task-create-warning(|ctx, msg))> warnings
 
   check-layout-constraints(|ctx, chars): prod -> <id>
     where
@@ -186,7 +187,8 @@ rules
       <try(check-align-list; create-errors(|ctx))> (rhs, attrs);
       <try(check-offside; create-errors(|ctx))> (rhs, attrs);
       <try(check-duplicate; create-errors(|ctx))> (rhs, attrs);
-      <try(check-order; create-errors(|ctx))> (rhs, attrs)
+      <try(check-order; create-errors(|ctx))> (rhs, attrs);
+      <try(check-irrelevant; create-warnings(|ctx))> (rhs, attrs)
 
 
   get-production-rhs(|chars): SdfProduction(_, Rhs(rhs), _) -> rhs
@@ -286,6 +288,16 @@ rules
   is-out-of-order(|rhs, ref): pos -> <ltS> (tree, ref)
     where
       PosRef(tree) := <get-tree-position(|rhs)> pos
+
+
+  check-irrelevant: (rhs, attrs) -> (warnings, "Irrelevant layout constraint, no reference of tree selectors")
+    where
+      constraints := <collect-all(?Eq(_,_) + ?Lt(_,_) + ?Le(_,_) + ?Gt(_,_) + ?Ge(_,_), conc); not(?[])> attrs;
+      warnings := <filter(is-irrelevant-constraint)> constraints
+
+  is-irrelevant-constraint: constraint -> <id>
+    where
+      <not(collect-one(?Line(_) + ?Col(_)))> constraint
 
 
 rules

--- a/org.metaborg.meta.lang.template/trans/generation/pp/to-pp.str
+++ b/org.metaborg.meta.lang.template/trans/generation/pp/to-pp.str
@@ -267,7 +267,7 @@ rules
     with
         <reset-counter> "pp";
         line'*           := <map(introduce-labels-line)> line*;
-        lc-selectors*    := <collect-om(?Offside(_, []) <+ ?AlignList(_) <+ ?PPOffside(_, []) <+ ?PPAlignList(_) <+ ?PosRef(_) <+ ?LabelRef(_) <+ ?LiteralRef(_), collapse-lists); strip-annos; nub> a*;
+        lc-selectors*    := <collect-om(?Offside(_, []) <+ ?AlignList(_) <+ ?PPOffside(_, []) <+ ?PPAlignList(_) <+ ?PosRef(_) <+ ?LabelRef(_) <+ ?LiteralRef(_), conc); strip-annos; nub> a*;
         line''*          := <annotate-lines(|lc-selectors*)> line'*;
         output           := <map(template-line-to-stratego(|lang))> line''*;
         arg*             := <mapconcat(?Line(<filter(placeholder-to-var)>))> line'*;
@@ -285,7 +285,7 @@ rules
     with
         layout-constraints := <collect-all(?Align(_, [_ | _]) + ?Offside(_, [_ | _]) + ?Indent(_, _) + ?NewLineIndent(_, _) + 
                                            ?PPAlign(_, [_ | _]) + ?PPOffside(_, [_ | _]) + ?PPIndent(_, _) + ?PPNewLineIndent(_, _) + 
-                                           ?PPNewLineIndentBy(_, _, _) + ?PPNewLine(_) + ?PPNewLineBy(_, _), collapse-lists)> a*;// collect layout constraints ;
+                                           ?PPNewLineIndentBy(_, _, _) + ?PPNewLine(_) + ?PPNewLineBy(_, _), conc)> a*;// collect layout constraints ;
         if <?[]> layout-constraints then
           rule := Rule(NoAnnoList(input), NoAnnoList(List(output')), with*)
         else
@@ -297,13 +297,13 @@ rules
   apply-align-layout-constraint(|t, a*):
     SingleLineTemplate(elem*) -> SingleLineTemplate(elem'*)
     where
-      pos-ref* := <collect-all(?AlignList(<id>) + ?PPAlignList(<id>), collapse-lists); not(?[])> a*;
+      pos-ref* := <collect-all(?AlignList(<id>) + ?PPAlignList(<id>), conc); not(?[])> a*;
       elem'*   := <replace-list-align(|pos-ref*)> (1, elem*)
       
   apply-align-layout-constraint(|t, a*):
     Template(line*) -> Template(line'*)
     where
-      pos-ref* := <collect-all(?AlignList(<id>) + ?PPAlignList(<id>), collapse-lists); not(?[])> a*;
+      pos-ref* := <collect-all(?AlignList(<id>) + ?PPAlignList(<id>), conc); not(?[])> a*;
       line'*   := <replace-list-align-line(|pos-ref*)> (1, line*)
       
   replace-list-align-line(|pos-ref*):
@@ -539,7 +539,7 @@ rules
     with
       <reset-counter> "pp";
       line'*        := <map(introduce-labels-line)> line*;
-      lc-selectors* := <collect-om(?AlignList(_) <+ ?Offside(_, []) <+ ?PPAlignList(_) <+ ?PPOffside(_, []) <+ ?PosRef(_) <+ ?LabelRef(_) <+ ?LiteralRef(_), collapse-lists); strip-annos; nub> a*;
+      lc-selectors* := <collect-om(?AlignList(_) <+ ?Offside(_, []) <+ ?PPAlignList(_) <+ ?PPOffside(_, []) <+ ?PosRef(_) <+ ?LabelRef(_) <+ ?LiteralRef(_), conc); strip-annos; nub> a*;
       line''*       := <annotate-lines(|lc-selectors*)> line'*;
       output        := <map(template-line-to-stratego(|lang))> line''*;
       arg*          := <mapconcat(?Line(<filter(placeholder-to-var)>))> line'*;
@@ -563,7 +563,7 @@ rules
     with
         layout-constraints := <collect-all(?Align(_, [_ | _]) + ?Offside(_, [_ | _]) + ?Indent(_, _) + ?NewLineIndent(_, _) + 
                                            ?PPAlign(_, [_ | _]) + ?PPOffside(_, [_ | _]) + ?PPIndent(_, _) + ?PPNewLineIndent(_, _) + 
-                                           ?PPNewLineIndentBy(_, _, _) + ?PPNewLine(_) + ?PPNewLineBy(_, _), collapse-lists)> a*;// collect layout constraints ;
+                                           ?PPNewLineIndentBy(_, _, _) + ?PPNewLine(_) + ?PPNewLineBy(_, _), conc)> a*;// collect layout constraints ;
         if <?[]> layout-constraints then
           rule := Rule(NoAnnoList(input), NoAnnoList(List(output')), cond*)
         else


### PR DESCRIPTION
In this PR I have written analysis tests for layout constraints. I have added tests for the error checks that were already there, but also added tests and implementation for new errors and 1 new warning. The new checks include

* A warning for declaring a low level constraint without using any tree references.
* Applying `offside` to one terminal produces an error, since this can never parse.
* Add errors for applying `offside`, `indent`, `align` and `newline-indent` to the same tree. For example, when working with indices and labels and accidentally using a label with the same index.
* Add error for applying `offside` and `newline-indent` to arguments which come before the reference position in the production, since this would never parse.

Please let me know if any of these errors are invalid or should be warnings.

Additionally, since the new syntax combines layout constraints and declarations, the errors and warnings work for both type of constraints. Furthermore, I have fixed some bugs where the tree position was off by one in the desugarer. Finally, I have reformatted and optimized the analysis for layout constraints to make it easier to add more checks in the future.