### PR TITLE
Fix: remove all constraint

### DIFF
--- a/org.metaborg.meta.lang.template/syntax/layout-constraints/Layout-Constraints.sdf3
+++ b/org.metaborg.meta.lang.template/syntax/layout-constraints/Layout-Constraints.sdf3
@@ -6,19 +6,8 @@ imports
   constants/StrCon
   constants/IdentifierCon
 
-lexical syntax
-
-  LayoutVar = [a-zA-Z] [a-zA-Z0-9]*
-  LayoutVar = "all" {reject}
-
-lexical restrictions
-
-  LayoutVar -/- [a-zA-Z0-9]
-  "all" -/- [a-zA-Z0-9]
-
 template options
 
-  LayoutVar = keyword {restrict}
   keyword -/- [a-zA-Z0-9]
 
 context-free sorts
@@ -47,7 +36,6 @@ context-free syntax
   ConstraintExp.Line = <<ConstraintToken>.line>
   ConstraintExp.Col = <<ConstraintToken>.col>
   ConstraintExp.Num = NatCon
-  ConstraintExp.LayoutVar = LayoutVar
 
   Constraint = <(<Constraint>)> {bracket}
   Constraint.Eq = <<ConstraintExp> == <ConstraintExp>> {non-assoc}
@@ -58,9 +46,6 @@ context-free syntax
   Constraint.Not = <!<Constraint>>
   Constraint.And = <<Constraint> && <Constraint>> {left}
   Constraint.Or = <<Constraint> || <Constraint>> {left}
-
-  Constraint.All = <all(<LayoutVar>, <Constraint>, <Constraint>)> {
-    deprecated("The 'all' layout constraint will be removed in a future version. Use align-list instead")}
 
   Constraint.Offside = <offside <ConstraintTreeRef> <{ConstraintTreeRef ", "}*>>
   Constraint.Indent = <indent <ConstraintTreeRef> <{ConstraintTreeRef ", "}+>>


### PR DESCRIPTION
In a previous PR of mine (#51) I deprecated the `all` layout constraint. However, I have done another thorough search and the constraint is not desugared or used in the parse table. So, syntax with this constraint does not even compile. Therefore, I suggest to remove it, since it is not used anywhere and the constraint used to be a hack to implement other layout declarations, which now have their own implementation. Please let me know if you know a place where it _is_ used.