### PR TITLE
Auto generate namespaced grammar

### DIFF
--- a/org.metaborg.meta.lang.template/metaborg.yaml
+++ b/org.metaborg.meta.lang.template/metaborg.yaml
@@ -24,6 +24,8 @@ generates:
   directory: src-gen
 - language: SDF
   directory: src-gen/syntax
+- language: TemplateLang
+  directory: src-gen/syntax
 - language: ds
   directory: src-gen
 exports:

--- a/org.metaborg.meta.lang.template/metaborg.yaml
+++ b/org.metaborg.meta.lang.template/metaborg.yaml
@@ -24,8 +24,6 @@ generates:
   directory: src-gen
 - language: SDF
   directory: src-gen/syntax
-- language: TemplateLang
-  directory: src-gen/syntax
 - language: ds
   directory: src-gen
 exports:

--- a/org.metaborg.meta.lang.template/trans/editor/build-all.str
+++ b/org.metaborg.meta.lang.template/trans/editor/build-all.str
@@ -39,7 +39,7 @@ imports
   
 rules 
   check-sdf2table = prim("SSL_EXT_check_sdf2_table") <+ !"unknown"
-  
+  generate-namespaced-grammar = prim("generate_namespaced_grammar")
 
 
 rules
@@ -48,12 +48,14 @@ rules
   generate-all:
     t -> ([filename1*, filename2*], [string1*, string2*])
     where
+      generate-namespaced-grammar;
       (filename1*, string1*) := <generate-all-base> t;
       (filename2*, string2*) := <sdf3-to-namespaced(generate-all-namespaced(|t))> t
 
   generate-all:
     t -> <generate-all-base> t
     where
+      not(generate-namespaced-grammar) <+
       None() := <sdf3-to-namespaced(generate-all-namespaced(|t))> t
 
   generate-all-namespaced(|(selected, position, _, _, project-path)):

--- a/org.metaborg.meta.lang.template/trans/editor/build-all.str
+++ b/org.metaborg.meta.lang.template/trans/editor/build-all.str
@@ -26,6 +26,7 @@ imports
 imports
   analysis/desugar
   editor/build-utils
+  editor/build-syntax
   generation/completion/-
   generation/pp/-
   generation/signatures/-
@@ -34,6 +35,7 @@ imports
   libstrc
   normalization/to-normal-form
   libstratego-aterm
+  trans/pp
   
 rules 
   check-sdf2table = prim("SSL_EXT_check_sdf2_table") <+ !"unknown"
@@ -44,6 +46,22 @@ rules
 
 // On-save handler
   generate-all:
+    t -> ([filename1*, filename2*], [string1*, string2*])
+    where
+      (filename1*, string1*) := <generate-all-base> t;
+      (filename2*, string2*) := <sdf3-to-namespaced(generate-all-namespaced(|t))> t
+
+  generate-all : t -> <generate-all-base> t
+    where
+      None() := <sdf3-to-namespaced(generate-all-namespaced(|t))> t
+
+  generate-all-namespaced(|(selected, position, _, _, project-path)):
+    (namespaced-filename, namespaced-ast) -> ([namespaced-filename | filename*], [namespaced-string | string*])
+  where
+    namespaced-string := <pp-SDF3-string> namespaced-ast;
+    (filename*, string*) := <generate-all-base> (selected, position, namespaced-ast, namespaced-filename, project-path)
+
+  generate-all-base:
     (selected, position, ast, path, project-path) -> result
     where
       filename := <base-filename> path;

--- a/org.metaborg.meta.lang.template/trans/editor/build-all.str
+++ b/org.metaborg.meta.lang.template/trans/editor/build-all.str
@@ -51,15 +51,16 @@ rules
       (filename1*, string1*) := <generate-all-base> t;
       (filename2*, string2*) := <sdf3-to-namespaced(generate-all-namespaced(|t))> t
 
-  generate-all : t -> <generate-all-base> t
+  generate-all:
+    t -> <generate-all-base> t
     where
       None() := <sdf3-to-namespaced(generate-all-namespaced(|t))> t
 
   generate-all-namespaced(|(selected, position, _, _, project-path)):
     (namespaced-filename, namespaced-ast) -> ([namespaced-filename | filename*], [namespaced-string | string*])
-  where
-    namespaced-string := <pp-SDF3-string> namespaced-ast;
-    (filename*, string*) := <generate-all-base> (selected, position, namespaced-ast, namespaced-filename, project-path)
+    where
+      namespaced-string := <pp-SDF3-string> namespaced-ast;
+      (filename*, string*) := <generate-all-base> (selected, position, namespaced-ast, namespaced-filename, project-path)
 
   generate-all-base:
     (selected, position, ast, path, project-path) -> result

--- a/org.metaborg.meta.lang.template/trans/editor/build-syntax.str
+++ b/org.metaborg.meta.lang.template/trans/editor/build-syntax.str
@@ -75,7 +75,7 @@ rules
       <?Module(Unparameterized(mn), i*, sections)> ast ;
       dirname := <dirname> path;
       lang := <language-spec-name>;
-      if <not(is-substring(!"namespaced"))> dirname then
+      if <not(is-substring(!"namespaced"))> mn then
         norm-namespaced-filename       := <get-src-gen(|project-path, $[syntax/[lang]], "-namespaced.sdf3")> mn;
         norm-namespaced-ast            := <module-to-namespaced> ast;
         norm-namespaced-result         := <s> (norm-namespaced-filename, norm-namespaced-ast)

--- a/org.metaborg.meta.lang.template/trans/editor/build-syntax.str
+++ b/org.metaborg.meta.lang.template/trans/editor/build-syntax.str
@@ -67,15 +67,18 @@ rules
         ast'     := <desugar-templates> selected;
         result   := <module-to-permissive-productions; pp-SDF3-string> ast'
 
-  sdf3-to-namespaced:
+  sdf3-to-namespaced = sdf3-to-namespaced((id, pp-SDF3-string))
+
+  sdf3-to-namespaced(s):
     (selected, position, ast, path, project-path) -> norm-namespaced-result
     where
       <?Module(Unparameterized(mn), i*, sections)> ast ;
       dirname := <dirname> path;
+      lang := <language-spec-name>;
       if <not(is-substring(!"namespaced"))> dirname then
-        norm-namespaced-filename       := <concat-strings> [project-path, "/syntax/namespaced/", mn, "-namespaced.sdf3"];
+        norm-namespaced-filename       := <get-src-gen(|project-path, $[syntax/[lang]], "-namespaced.sdf3")> mn;
         norm-namespaced-ast            := <module-to-namespaced> ast;
-        norm-namespaced-result         := (norm-namespaced-filename, <pp-SDF3-string> norm-namespaced-ast)
+        norm-namespaced-result         := <s> (norm-namespaced-filename, norm-namespaced-ast)
       else
         result := None()
       end

--- a/org.metaborg.meta.lang.template/trans/generation/syntax/to-namespaced.str
+++ b/org.metaborg.meta.lang.template/trans/generation/syntax/to-namespaced.str
@@ -46,6 +46,7 @@ rules
   namespace-module-name:
     mn -> mn'
     where
+      // TODO: test if module exists in this project, otherwise don't rename
       lang       := <language-spec-name>;
       mn'        :=  <concat-strings> [lang, "/", mn, "-namespaced"]
       
@@ -58,6 +59,7 @@ rules
   namespace-sort:
     Sort(x) -> Sort(x')
     where
+      // TODO: test if only defined in this project, otherwise don't rename
       capital-lang-name := <string-as-chars(to-upper-first-char)> <language-spec-name>;
       x'                := <concat-strings> [capital-lang-name, "-", x]
       

--- a/org.metaborg.meta.lang.template/trans/generation/syntax/to-namespaced.str
+++ b/org.metaborg.meta.lang.template/trans/generation/syntax/to-namespaced.str
@@ -39,14 +39,15 @@ rules
   module-to-namespaced:
     Module(Unparameterized(mn), i*, sections*) -> Module(Unparameterized(mn'), i'*, sections'*)
     where
-      mn'        :=  <concat-strings> [mn, "-namespaced"];
+      mn'        :=  <namespace-module-name> mn;
       sections'* := <topdown(try(namespace-sort))> sections*;
-      i'*        := <topdown(try(namespace-module-name))> i*
+      i'*        := <topdown(try(Module(Unparameterized(namespace-module-name))))> i*
       
   namespace-module-name:
-    Module(Unparameterized(mn)) -> Module(Unparameterized(mn'))
+    mn -> mn'
     where
-      mn'        :=  <concat-strings> [mn, "-namespaced"]
+      lang       := <language-spec-name>;
+      mn'        :=  <concat-strings> [lang, "/", mn, "-namespaced"]
       
   namespace-sort:
     DeclSort(x) -> DeclSort(x')


### PR DESCRIPTION
PR required to be merged with or before this one: https://github.com/metaborg/spoofax/pull/82

Before this commit you would need to call a menu item manually to generate a namespaced grammar file. This was done because the generated file would be put into the `syntax` directory. Those were put there because the files needed to have the SDF3 on-save handler called on them as well.
With these changes, that menu is called on-save. The generated file will end up in `src-gen` instead of `syntax`. The `on-save` handler generates all other files for the namespaced grammar as it generates the namespaced grammar. 

Extra feature added: The namespaced grammar ends up in a subdirectory by the name of the language. This is to avoid module name clashes when mixing two namespaced grammars. 