### PR TITLE
Sdf3 meta

### DIFF
--- a/org.metaborg.sdf3.meta.integrationtest/.gitignore
+++ b/org.metaborg.sdf3.meta.integrationtest/.gitignore
@@ -1,0 +1,14 @@
+/.cache
+/bin
+/src-gen
+/target
+
+/.classpath
+/.project
+/.settings
+/.factorypath
+
+/.polyglot.metaborg.yaml
+
+/trans/foo.tbl
+/trans/table-foo.bin

--- a/org.metaborg.sdf3.meta.integrationtest/.mvn/extensions.xml
+++ b/org.metaborg.sdf3.meta.integrationtest/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+  <extension>
+    <groupId>org.metaborg</groupId>
+    <artifactId>spoofax-maven-plugin-pomless</artifactId>
+    <version>2.6.0-SNAPSHOT</version>
+  </extension>
+</extensions>

--- a/org.metaborg.sdf3.meta.integrationtest/editor/Main.esv
+++ b/org.metaborg.sdf3.meta.integrationtest/editor/Main.esv
@@ -1,0 +1,10 @@
+module Main
+
+language
+
+  extensions : s3mit
+
+  provider : target/metaborg/stratego.ctree
+
+  table         : target/metaborg/sdf.tbl
+  start symbols : Start

--- a/org.metaborg.sdf3.meta.integrationtest/editor/Main.esv
+++ b/org.metaborg.sdf3.meta.integrationtest/editor/Main.esv
@@ -8,3 +8,11 @@ language
 
   table         : target/metaborg/sdf.tbl
   start symbols : Start
+
+menus
+
+  menu: "Transform"
+
+    action: "Swap (abstract syntax)"        = swap-editor-abstract-syntax        (source)
+    action: "Swap (concrete syntax)"        = swap-editor-concrete-syntax        (source)
+    action: "Swap (concrete syntax simple)" = swap-editor-concrete-syntax-simple (source)

--- a/org.metaborg.sdf3.meta.integrationtest/metaborg.yaml
+++ b/org.metaborg.sdf3.meta.integrationtest/metaborg.yaml
@@ -1,0 +1,40 @@
+---
+id: org.metaborg:sdf3.meta.integrationtest:2.6.0-SNAPSHOT
+name: sdf3-meta-integrationtest
+dependencies:
+  compile:
+  - org.metaborg:org.metaborg.meta.lang.esv:${metaborgVersion}
+  - org.metaborg:org.metaborg.meta.lang.template:${metaborgVersion}
+  - org.metaborg:org.metaborg.meta.lang.spt:${metaborgVersion}
+  source:
+  - org.metaborg:meta.lib.spoofax:${metaborgVersion}
+pardonedLanguages:
+- EditorService
+- Stratego-Sugar
+- SDF
+language:
+  sdf:
+    pretty-print: sdf3-meta-integrationtest
+    version: sdf3
+    sdf2table: java
+    sdf-meta:
+     - foo
+    placeholder:
+      prefix: "$"
+  stratego:
+    format: ctree
+    args:
+    - -la
+    - stratego-lib
+    - -la
+    - stratego-sglr
+    - -la
+    - stratego-gpp
+    - -la
+    - stratego-xtc
+    - -la
+    - stratego-aterm
+    - -la
+    - stratego-sdf
+    - -la
+    - strc

--- a/org.metaborg.sdf3.meta.integrationtest/metaborg.yaml
+++ b/org.metaborg.sdf3.meta.integrationtest/metaborg.yaml
@@ -8,6 +8,7 @@ dependencies:
   - org.metaborg:org.metaborg.meta.lang.spt:${metaborgVersion}
   source:
   - org.metaborg:meta.lib.spoofax:${metaborgVersion}
+  - org.metaborg:stratego.lang:${metaborgVersion}
 pardonedLanguages:
 - EditorService
 - Stratego-Sugar

--- a/org.metaborg.sdf3.meta.integrationtest/pom.xml
+++ b/org.metaborg.sdf3.meta.integrationtest/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>sdf3.meta.integrationtest</artifactId>
+  <packaging>spoofax-language</packaging>
+
+  <parent>
+    <groupId>org.metaborg</groupId>
+    <artifactId>parent.language</artifactId>
+    <version>2.6.0-SNAPSHOT</version>
+    <relativePath>../../releng/parent/java</relativePath>
+  </parent>
+  
+  <dependencies>
+    <!-- compile -->
+    <dependency>
+      <groupId>org.metaborg</groupId>
+      <artifactId>org.metaborg.meta.lang.esv</artifactId>
+      <version>${metaborg-version}</version>
+      <type>spoofax-language</type>
+    </dependency>
+    <dependency>
+      <groupId>org.metaborg</groupId>
+      <artifactId>org.metaborg.meta.lang.spt</artifactId>
+      <version>${metaborg-version}</version>
+      <type>spoofax-language</type>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- source -->
+    <dependency>
+      <groupId>org.metaborg</groupId>
+      <artifactId>meta.lib.spoofax</artifactId>
+      <version>${metaborg-version}</version>
+      <type>spoofax-language</type>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.metaborg</groupId>
+        <artifactId>spoofax-maven-plugin</artifactId>
+        <version>${metaborg-version}</version>
+        <executions>
+          <execution>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <languageUnderTest>org.metaborg:sdf3.meta.integrationtest:${metaborg-version}</languageUnderTest>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/org.metaborg.sdf3.meta.integrationtest/syntax/foo.sdf3
+++ b/org.metaborg.sdf3.meta.integrationtest/syntax/foo.sdf3
@@ -2,7 +2,8 @@ module foo
 
 imports
 
-  StrategoLang/import
+  StrategoLang/import-namespaced
+  StrategoLang/sugar/terms-namespaced
   thesyntax
 
 context-free start-symbols

--- a/org.metaborg.sdf3.meta.integrationtest/syntax/foo.sdf3
+++ b/org.metaborg.sdf3.meta.integrationtest/syntax/foo.sdf3
@@ -1,0 +1,13 @@
+module foo
+
+context-free start-symbols
+  
+  Start
+
+context-free sorts
+
+  Start
+
+context-free syntax
+  
+  Start.Foo = <foo>

--- a/org.metaborg.sdf3.meta.integrationtest/syntax/foo.sdf3
+++ b/org.metaborg.sdf3.meta.integrationtest/syntax/foo.sdf3
@@ -1,13 +1,18 @@
 module foo
 
+imports
+
+  StrategoLang/import
+  thesyntax
+
 context-free start-symbols
-  
-  Start
 
-context-free sorts
-
-  Start
+  StrategoLang-Module
 
 context-free syntax
-  
-  Start.Foo = <foo>
+
+  StrategoLang-PreTerm.ToTerm = <|[ <Stmt> ]|>
+  StrategoLang-PreTerm.ToTerm = <stmt |[ <Stmt> ]|>
+
+  Exp.FromTerm = [~[StrategoLang-Term]]
+  Exp.FromTerm = [~exp:[StrategoLang-Term]]

--- a/org.metaborg.sdf3.meta.integrationtest/syntax/sdf3-meta-integrationtest.sdf3
+++ b/org.metaborg.sdf3.meta.integrationtest/syntax/sdf3-meta-integrationtest.sdf3
@@ -1,13 +1,8 @@
 module sdf3-meta-integrationtest
 
+imports
+  thesyntax
+
 context-free start-symbols
-  
-  Start
-
-context-free sorts
 
   Start
-
-context-free syntax
-  
-  Start.Bar = <bar>

--- a/org.metaborg.sdf3.meta.integrationtest/syntax/sdf3-meta-integrationtest.sdf3
+++ b/org.metaborg.sdf3.meta.integrationtest/syntax/sdf3-meta-integrationtest.sdf3
@@ -1,0 +1,13 @@
+module sdf3-meta-integrationtest
+
+context-free start-symbols
+  
+  Start
+
+context-free sorts
+
+  Start
+
+context-free syntax
+  
+  Start.Bar = <bar>

--- a/org.metaborg.sdf3.meta.integrationtest/syntax/thesyntax.sdf3
+++ b/org.metaborg.sdf3.meta.integrationtest/syntax/thesyntax.sdf3
@@ -1,0 +1,21 @@
+module thesyntax
+
+lexical sorts
+  VAR
+
+lexical syntax
+  LAYOUT = [\t\ \n\r]
+  VAR = [a-z]+
+
+context-free restrictions
+  LAYOUT? -/- [\ \t\n\r]
+
+context-free sorts
+  Start Stmt Exp
+
+context-free syntax
+
+  Start.Program = Stmt
+  Stmt.Stmt = [[Exp];]
+  Exp.Add = [[Exp] + [Exp]]
+  Exp.Var = VAR

--- a/org.metaborg.sdf3.meta.integrationtest/test/swap.spt
+++ b/org.metaborg.sdf3.meta.integrationtest/test/swap.spt
@@ -1,0 +1,11 @@
+module swap
+
+language sdf3-meta-integrationtest
+
+start symbol Start
+
+test swap [[x + y;]] transform "Transform -> Swap (abstract syntax)"        to [[y + x;]]
+
+test swap [[x + y;]] transform "Transform -> Swap (concrete syntax)"        to [[y + x;]]
+
+test swap [[x + y;]] transform "Transform -> Swap (concrete syntax simple)" to [[y + x;]]

--- a/org.metaborg.sdf3.meta.integrationtest/test/test.spt
+++ b/org.metaborg.sdf3.meta.integrationtest/test/test.spt
@@ -1,7 +1,0 @@
-module test
-
-language sdf3-meta-integrationtest
-
-start symbol Start
-
-test bar [[bar]] parse succeeds

--- a/org.metaborg.sdf3.meta.integrationtest/test/test.spt
+++ b/org.metaborg.sdf3.meta.integrationtest/test/test.spt
@@ -1,0 +1,7 @@
+module test
+
+language sdf3-meta-integrationtest
+
+start symbol Start
+
+test bar [[bar]] parse succeeds

--- a/org.metaborg.sdf3.meta.integrationtest/trans/sdf3_meta_integrationtest.str
+++ b/org.metaborg.sdf3.meta.integrationtest/trans/sdf3_meta_integrationtest.str
@@ -1,0 +1,1 @@
+module sdf3_meta_integrationtest

--- a/org.metaborg.sdf3.meta.integrationtest/trans/sdf3_meta_integrationtest.str
+++ b/org.metaborg.sdf3.meta.integrationtest/trans/sdf3_meta_integrationtest.str
@@ -1,1 +1,5 @@
 module sdf3_meta_integrationtest
+
+imports
+
+  swap

--- a/org.metaborg.sdf3.meta.integrationtest/trans/swap.meta
+++ b/org.metaborg.sdf3.meta.integrationtest/trans/swap.meta
@@ -1,0 +1,1 @@
+Meta([Syntax("foo")])

--- a/org.metaborg.sdf3.meta.integrationtest/trans/swap.str
+++ b/org.metaborg.sdf3.meta.integrationtest/trans/swap.str
@@ -1,0 +1,26 @@
+module swap
+
+imports
+
+  libstratego-lib
+  signatures/-
+
+rules
+
+  swap-editor-abstract-syntax        = swap-editor(swap-exp-abstract-syntax|)
+  swap-editor-concrete-syntax        = swap-editor(swap-exp-concrete-syntax|)
+  swap-editor-concrete-syntax-simple = swap-editor(swap-exp-concrete-syntax-simple|)
+
+  swap-editor(swap-exp|):
+    (_, _, ast, path, _) -> (path, <topdown(try(swap-exp))> ast) 
+
+  swap-exp-abstract-syntax:
+    Add(e1, e2) -> Add(e2, e1)
+
+  swap-exp-concrete-syntax:
+    stmt |[ ~exp:e1 + ~exp:e2 ; ]| ->
+    stmt |[ ~exp:e2 + ~exp:e1 ; ]|
+
+  swap-exp-concrete-syntax-simple:
+    |[ ~e1 + ~e2 ; ]| ->
+    |[ ~e2 + ~e1 ; ]|


### PR DESCRIPTION
This PR adds extra parse table generation like the `sdf-meta` config option for SDF2. These are mixed grammar parse tables. The default is to look for a `Stratego-<language-name>.sdf3` file, and use it as the starting point to build a `Stratego-<language-name>.tbl` file. This is the most common use of parse table generation. 
There is an integration test in this PR to have a test for the extra parse table generation. **However,** this uses the new Stratego 2 meta-language for an SDF3 source of the namespaced(!) Stratego grammar. Generating and exporting the namespaced Stratego grammar from Stratego 2 is something that requires the release of Spoofax 2.5.15. So this is a draft PR until the next Spoofax release. 

Edit:
Aaaaand there was a bug in the namespaced grammar generation which only shows up in the Maven build, whereas it was tested in the Eclipse build. So although 2.5.15 is released, only 2.5.16 will have a version that works...