### PR TITLE
Fix: null pointer exception on Boolean constraint normalize

### DIFF
--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/layoutconstraints/BooleanLayoutConstraint.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/layoutconstraints/BooleanLayoutConstraint.java
@@ -41,7 +41,9 @@ public class BooleanLayoutConstraint implements ILayoutConstraint {
 
     @Override public void normalizeConstraint(List<ISymbol> rhs) {
         this.c1.normalizeConstraint(rhs);
-        this.c2.normalizeConstraint(rhs);
+        if (this.op != LayoutConstraintBooleanOperator.NOT) {
+            this.c2.normalizeConstraint(rhs);
+        }
     }
 
     @Override public boolean equals(Object other) {


### PR DESCRIPTION
Fixed an issue where a boolean not constraint gave a `NullPointerException` when being normalized, since the second operand is `null` for not.