### PR TITLE
Fix layout constraint desugar

### DIFF
--- a/org.metaborg.meta.lang.template.test/layout-constraints/analysis-attributes.spt
+++ b/org.metaborg.meta.lang.template.test/layout-constraints/analysis-attributes.spt
@@ -1,0 +1,43 @@
+module layout-constraints/analysis-attributes
+
+language TemplateLang
+
+test 2 layout attributes [[
+module layout-constraints/analysis-attributes
+
+context-free syntax
+  A.A = "A" {layout(0.first.line == 1), [[layout(0.first.line == 2)]]}
+]] 1 error at #1
+
+test more layout attributes [[
+module layout-constraints/analysis-attributes
+
+context-free syntax
+  A.A = "A" {
+    layout(0.first.line == 1),
+    [[layout(0.first.line == 2)]],
+    deprecated,
+    [[layout(0.first.line == 3)]]
+ }
+]] 2 error at #1, #2
+
+test layout and ignore-layout [[
+module layout-constraints/analysis-attributes
+
+context-free syntax
+  A.A = "A" {layout(0.first.line == 1), [[ignore-layout]]}
+]] 1 error at #1
+
+test ignore-layout and layout [[
+module layout-constraints/analysis-attributes
+
+context-free syntax
+  A.A = "A" {ignore-layout, [[layout(0.first.line == 1)]]}
+]] 1 error at #1
+
+test ignore-layout and layout and ignore-layout [[
+module layout-constraints/analysis-attributes
+
+context-free syntax
+  A.A = "A" {ignore-layout, [[layout(0.first.line == 1)]], [[ignore-layout]]}
+]] 2 errors at #1, #2

--- a/org.metaborg.meta.lang.template.test/layout-constraints/analysis.spt
+++ b/org.metaborg.meta.lang.template.test/layout-constraints/analysis.spt
@@ -69,6 +69,11 @@ test align list index invalid non-terminal [[align-list [[3]] ]] 1 error at #1
 test align list index invalid terminal [[align-list [[1]] ]] 1 error at #1
 test align list out of bounds index [[align-list [[6]] ]] 1 error at #1
 test align list invalid label [[align-list [[z]] ]] 1 error at #1
+test not align-list [[ [[!align-list l]] ]] 1 error at #1
+test or align-list [[1.first.line == 1 || [[align-list l]] ]] 1 error at #1
+test not and or nested align-list [[
+align-list l && ([[align-list l]] || [[align-list l]] || ![[align-list l]]) && align-list c
+]] 3 errors at #1, #2, #3
 
 test newline indent label one [[newline-indent b c]] analysis succeeds
 test newline indent index one [[newline-indent 1 2]] analysis succeeds

--- a/org.metaborg.meta.lang.template.test/layout-constraints/desugar.spt
+++ b/org.metaborg.meta.lang.template.test/layout-constraints/desugar.spt
@@ -1,0 +1,90 @@
+module desugar
+
+language TemplateLang
+
+test desugar pos ref [[
+module desugar
+context-free syntax
+A.A = "A" {layout(0.first.line == 1)}
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = "A" {layout(0.first.line == 1)}
+]]
+
+test desugar literal ref [[
+module desugar
+context-free syntax
+A.A = "A" {layout("A".first.line == 1)}
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = "A" {layout(0.first.line == 1)}
+]]
+
+test desugar label ref [[
+module desugar
+context-free syntax
+A.A = a:A {layout(a.first.line == 1)}
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = a:A {layout(0.first.line == 1)}
+]]
+
+test desugar ref in exp [[
+module desugar
+context-free syntax
+A.A = a:A b:A {layout(a.first.line + b.last.line >= 1)}
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = a:A b:A {layout(0.first.line + 1.last.line >= 1)}
+]]
+
+test template desugar ref in nested constraints [[
+module desugar
+context-free syntax
+A.A = <<a:A> <b:A> c> {
+  layout(a.first.line >= 1 && b.last.col == 2 || ! "c".right.line == 1)
+}
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = <<a:A> <b:A> c> {
+  layout(0.first.line >= 1 && 1.last.col == 2 || ! 2.right.line == 1)
+}
+]]
+
+test desugar offside one [[
+module desugar
+context-free syntax
+A.A = a:A {layout(offside a)}
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = a:A {layout(0.left.col > 0.first.col)}
+]]
+
+test desugar offside multiple [[
+module desugar
+context-free syntax
+A.A = a:A b:A "c" "d" {layout(offside a b, "c", 3)}
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = a:A b:A "c" "d" {
+  layout(
+    1.left.col > 0.first.col && (2.left.col > 0.first.col && (3.left.col > 0.first.col)))
+  }
+]]
+
+test desugar offside or offside [[
+module desugar
+context-free syntax
+A.A = a:A b:A {layout(offside a || offside b)}
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = a:A b:A {layout(0.left.col > 0.first.col || 1.left.col > 1.first.col)}
+]]

--- a/org.metaborg.meta.lang.template.test/layout-constraints/desugar.spt
+++ b/org.metaborg.meta.lang.template.test/layout-constraints/desugar.spt
@@ -114,9 +114,8 @@ A.A = a:A b:A "c" "d" {layout(offside a b, "c", 3)}
 module desugar
 context-free syntax
 A.A = a:A b:A "c" "d" {
-  layout(
-    1.left.col > 0.first.col && (2.left.col > 0.first.col && (3.left.col > 0.first.col)))
-  }
+  layout(1.left.col > 0.first.col && 2.left.col > 0.first.col && 3.left.col > 0.first.col)
+}
 ]]
 
 test desugar offside or offside [[
@@ -169,7 +168,9 @@ B.B = <b>
 ]] run test-desugar-layout-constraints to [[
 module desugar
 context-free syntax
-A.A = <i <b1:B> <b2:B> <b3:B>> {layout(1.first.col > 0.first.col && (2.first.col > 0.first.col && (3.first.col > 0.first.col)))}
+A.A = <i <b1:B> <b2:B> <b3:B>> {
+  layout(1.first.col > 0.first.col && 2.first.col > 0.first.col && 3.first.col > 0.first.col)
+}
 B.B = <b>
 ]]
 
@@ -190,7 +191,9 @@ A.A = <a b c d> {layout(align "a" "b", 2, "d")}
 ]] run test-desugar-layout-constraints to [[
 module desugar
 context-free syntax
-A.A = <a b c d> {layout(1.first.col == 0.first.col && (2.first.col == 0.first.col && (3.first.col == 0.first.col)))}
+A.A = <a b c d> {
+  layout(1.first.col == 0.first.col && 2.first.col == 0.first.col && 3.first.col == 0.first.col)
+}
 ]]
 
 test desugar newline-indent one [[
@@ -213,8 +216,8 @@ module desugar
 context-free syntax
 A.A = <a <b:B> c <B>> {
   layout((1.first.col > 0.first.col && 1.first.line > 0.last.line) &&
-         ((2.first.col > 0.first.col && 2.first.line > 0.last.line) &&
-         (3.first.col > 0.first.col && 3.first.line > 0.last.line))
+         (2.first.col > 0.first.col && 2.first.line > 0.last.line) &&
+         (3.first.col > 0.first.col && 3.first.line > 0.last.line)
         )
 }
 B.B = "b"

--- a/org.metaborg.meta.lang.template.test/layout-constraints/desugar.spt
+++ b/org.metaborg.meta.lang.template.test/layout-constraints/desugar.spt
@@ -1,4 +1,4 @@
-module desugar
+module layout-constraints/desugar
 
 language TemplateLang
 
@@ -30,6 +30,46 @@ A.A = a:A {layout(a.first.line == 1)}
 module desugar
 context-free syntax
 A.A = a:A {layout(0.first.line == 1)}
+]]
+
+test desugar quoted label [[
+module desugar
+context-free syntax
+A.A = "a":A {layout(a.first.line == a.last.line)}
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = "a":A {layout(0.first.line == 0.last.line)}
+]]
+
+test desugar labeled quoted literal [[
+module desugar
+context-free syntax
+A.A = a:"a" b:"b" {layout(a.first.line == "b".last.line)}
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = a:"a" b:"b" {layout(0.first.line == 1.last.line)}
+]]
+
+test desugar single quoted literal [[
+module desugar
+context-free syntax
+A.A = 'a' 'b' {layout("a".first.line == "b".last.line)}
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = 'a' 'b' {layout(0.first.line == 1.last.line)}
+]]
+
+test desugar single quoted literal [[
+module desugar
+context-free syntax
+A.A = a:"a" b:"b" {layout(a.first.line == b.last.line)}
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = a:"a" b:"b" {layout(0.first.line == 1.last.line)}
 ]]
 
 test desugar ref in exp [[
@@ -88,3 +128,167 @@ module desugar
 context-free syntax
 A.A = a:A b:A {layout(0.left.col > 0.first.col || 1.left.col > 1.first.col)}
 ]]
+
+test desugar offisde and offside [[
+module desugar
+context-free syntax
+A.A = a:A b:A {layout(offside a && offside b)}
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = a:A b:A {layout(0.left.col > 0.first.col && 1.left.col > 1.first.col)}
+]]
+
+test desugar not offside [[
+module desugar
+context-free syntax
+A.A = a:A b:A {layout(!offside a b)}
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = a:A b:A {layout(!1.left.col > 0.first.col)}
+]]
+
+test desugar indent one [[
+module desugar
+context-free syntax
+A.A = <i <b:B>> {layout(indent "i" b)}
+B.B = <b>
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = <i <b:B>> {layout(1.first.col > 0.first.col)}
+B.B = <b>
+]]
+
+test desugar indent multiple [[
+module desugar
+context-free syntax
+A.A = <i <b1:B> <b2:B> <b3:B>> {layout(indent "i" b1, b2, b3)}
+B.B = <b>
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = <i <b1:B> <b2:B> <b3:B>> {layout(1.first.col > 0.first.col && (2.first.col > 0.first.col && (3.first.col > 0.first.col)))}
+B.B = <b>
+]]
+
+test desugar align one [[
+module desugar
+context-free syntax
+A.A = <a b> {layout(align "a" "b")}
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = <a b> {layout(1.first.col == 0.first.col)}
+]]
+
+test desugar multiple [[
+module desugar
+context-free syntax
+A.A = <a b c d> {layout(align "a" "b", 2, "d")}
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = <a b c d> {layout(1.first.col == 0.first.col && (2.first.col == 0.first.col && (3.first.col == 0.first.col)))}
+]]
+
+test desugar newline-indent one [[
+module desugar
+context-free syntax
+A.A = <a b> {layout(newline-indent "a" "b")}
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = <a b> {layout(1.first.col > 0.first.col && 1.first.line > 0.last.line)}
+]]
+
+test desugar newline-indent one [[
+module desugar
+context-free syntax
+A.A = <a <b:B> c <B>> {layout(newline-indent "a" b, "c", 3)}
+B.B = "b"
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = <a <b:B> c <B>> {
+  layout((1.first.col > 0.first.col && 1.first.line > 0.last.line) &&
+         ((2.first.col > 0.first.col && 2.first.line > 0.last.line) &&
+         (3.first.col > 0.first.col && 3.first.line > 0.last.line))
+        )
+}
+B.B = "b"
+]]
+
+test desugar align-list iter [[
+module desugar
+context-free syntax
+A.A = b:B+ {layout(align-list b)}
+B.B = <b>
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = b:B+ {}
+B.B = <b>
+B+ = B+ B {layout(0.first.col == 1.first.col)}
+]]
+
+test desugar align-list iter index [[
+module desugar
+context-free syntax
+A.A = B+ {layout(align-list 0)}
+B.B = <b>
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = B+ {}
+B.B = <b>
+B+ = B+ B {layout(0.first.col == 1.first.col)}
+]]
+
+test desugar align-list iterstar [[
+module desugar
+context-free syntax
+A.A = b:B* {layout(align-list b)}
+B.B = <b>
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = b:B* {}
+B.B = <b>
+B+ = B+ B {layout(0.first.col == 1.first.col)}
+]]
+
+test desugar align-list iterstar [[
+module desugar
+context-free syntax
+A.A = B* {layout(align-list 0)}
+B.B = <b>
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = B* {}
+B.B = <b>
+B+ = B+ B {layout(0.first.col == 1.first.col)}
+]]
+
+test desugar multiple sections productions [[
+module desugar
+context-free syntax
+A.A = B C {layout(align 0 1)}
+A.B = <a <b:B>> {layout(offside "a" b)}
+context-free syntax
+B.B = <b <c:C>> {layout("b".first.line == c.last.line)}
+context-free syntax
+C.C = <c d> {layout("c".first.col == "d".first.col)}
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = B C {layout(1.first.col == 0.first.col)}
+A.B = <a <b:B>> {layout(1.left.col > 0.first.col)}
+context-free syntax
+B.B = <b <c:C>> {layout(0.first.line == 1.last.line)}
+context-free syntax
+C.C = <c d> {layout(0.first.col == 1.first.col)}
+]]
+

--- a/org.metaborg.meta.lang.template/trans/analysis/desugar.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/desugar.str
@@ -202,85 +202,81 @@ rules
       sections'* := <map(try(desugar-lc-section(|chars)))> sections*
 
   desugar-lc-section(|chars):
-    SDFSection(ContextFreeSyntax(p*)) -> SDFSection(ContextFreeSyntax([p'*, align-list*]))
+    SDFSection(ContextFreeSyntax(p*)) -> SDFSection(ContextFreeSyntax(<conc> (p'*, align-list*)))
     where
       align-list* := <filter(create-productions-align-list(|chars)); flatten-list; nub> p*;
-      p'*         := <map(desugar-lc-prod(|chars)); topdown(repeat(remove-align-list-and-pp-constraints)); topdown(try(flatten-list))> p*
+      p'*         := <map(desugar-lc-prod(|chars))> p*
 
   desugar-lc-section(|chars):
-    SDFSection(Kernel(p*)) -> SDFSection(Kernel([p'*, align-list*]))
+    SDFSection(Kernel(p*)) -> SDFSection(Kernel(<conc> (p'*, align-list*)))
     where
       align-list* := <filter(create-productions-align-list(|chars)); flatten-list; nub> p*;
-      p'*         := <map(desugar-lc-prod(|chars)); topdown(repeat(remove-align-list-and-pp-constraints)); topdown(try(flatten-list))> p*
+      p'*         := <map(desugar-lc-prod(|chars))> p*
 
   create-productions-align-list(|chars):
-    SdfProduction(lhs, Rhs(rhs*), Attrs(attrs*)) -> prods*
-    where
-      pos*           := <collect-all(?AlignList(<id>), conc); not(?[])> attrs*;
-      non-terminals* := <map(get-non-terminal-symbol(|rhs*))> pos*;
-      prods*         := <filter(generate-align-productions)> non-terminals*
+    SdfProduction(lhs, Rhs(rhs*), Attrs(attrs*)) -> <create-align-productions(|rhs*)> attrs*
 
   create-productions-align-list(|chars):
-    SdfProductionWithCons(lhs, Rhs(rhs*), Attrs(attrs*)) -> prods*
-    where
-      pos*           := <collect-all(?AlignList(<id>), conc); not(?[])> attrs*;
-      non-terminals* := <map(get-non-terminal-symbol(|rhs*))> pos*;
-      prods*         := <filter(generate-align-productions)> non-terminals*
+    SdfProductionWithCons(lhs, Rhs(rhs*), Attrs(attrs*)) -> <create-align-productions(|rhs*)> attrs*
 
   create-productions-align-list(|chars):
-    t@TemplateProduction(lhs, rhs, Attrs(attrs*)) -> prods*
+    t@TemplateProduction(lhs, rhs, Attrs(attrs*)) -> <create-align-productions(|rhs*)> attrs*
     where
-      rhs*           := <get-production-rhs(|chars)> t;
-      pos*           := <collect-all(?AlignList(<id>), conc); not(?[])> attrs*;
-      non-terminals* := <map(get-non-terminal-symbol(|rhs*))> pos*;
-      prods*         := <filter(generate-align-productions)> non-terminals*
+      rhs*  := <get-production-rhs(|chars)> t
 
   create-productions-align-list(|chars):
-    t@TemplateProductionWithCons(lhs, rhs, Attrs(attrs*)) -> prods*
+    t@TemplateProductionWithCons(lhs, rhs, Attrs(attrs*)) -> <create-align-productions(|rhs*)> attrs*
     where
-      rhs*           := <get-production-rhs(|chars)> t;
-      pos*           := <collect-all(?AlignList(<id>), conc); not(?[])> attrs*;
-      non-terminals* := <map(get-non-terminal-symbol(|rhs*))> pos*;
-      prods*         := <filter(generate-align-productions)> non-terminals*
+      rhs*  := <get-production-rhs(|chars)> t
 
-  generate-align-productions:
+  create-align-productions(|rhs*) =
+    collect-all(?AlignList(<id>), conc);
+    map(get-non-terminal-symbol(|rhs*));
+    filter(create-align-production)
+
+  create-align-production:
     Iter(s) -> SdfProduction(Iter(s), Rhs([Iter(s), s]), Attrs([LayoutConstraint(Eq(Col(First(PosRef("0"))), Col(First(PosRef("1")))))]))
 
-  generate-align-productions:
+  create-align-production:
     IterStar(s) -> SdfProduction(Iter(s), Rhs([Iter(s), s]), Attrs([LayoutConstraint(Eq(Col(First(PosRef("0"))), Col(First(PosRef("1")))))]))
 
-  generate-align-productions:
+  create-align-production:
     IterSep(s, sep) -> SdfProduction(IterSep(s, sep), Rhs([IterSep(s, sep), sep, s]), Attrs([LayoutConstraint(Eq(Col(First(PosRef("0"))), Col(First(PosRef("2")))))]))
 
-  generate-align-productions:
+  create-align-production:
     IterStarSep(s, sep) -> SdfProduction(IterSep(s, sep), Rhs([IterSep(s, sep), sep, s]), Attrs([LayoutConstraint(Eq(Col(First(PosRef("0"))), Col(First(PosRef("2")))))]))
 
   desugar-lc-prod(|chars):
     SdfProduction(lhs, Rhs(rhs*), Attrs(attrs*)) -> SdfProduction(lhs, Rhs(rhs*), Attrs(attrs'*))
     where
-      attrs'* := <map(try(desugar-lc-attr(|rhs*)))> attrs*
+      attrs'* := <desugar-lc-attrs(|rhs*)> attrs*
 
   desugar-lc-prod(|chars):
     SdfProductionWithCons(lhs, Rhs(rhs*), Attrs(attrs*)) -> SdfProductionWithCons(lhs, Rhs(rhs*), Attrs(attrs'*))
       where
-      attrs'* := <map(try(desugar-lc-attr(|rhs*)))> attrs*
+      attrs'* := <desugar-lc-attrs(|rhs*)> attrs*
 
   desugar-lc-prod(|chars):
     t@TemplateProduction(lhs, rhs, Attrs(attrs*)) -> TemplateProduction(lhs, rhs, Attrs(attrs'*))
     where
       rhs*    := <get-production-rhs(|chars)> t;
-      attrs'* := <map(try(desugar-lc-attr(|rhs*)))> attrs*
+      attrs'* := <desugar-lc-attrs(|rhs*)> attrs*
 
   desugar-lc-prod(|chars):
     t@TemplateProductionWithCons(lhs, rhs, Attrs(attrs*)) -> TemplateProductionWithCons(lhs, rhs, Attrs(attrs'*))
     where
       rhs*    := <get-production-rhs(|chars)> t;
-      attrs'* := <map(try(desugar-lc-attr(|rhs*)))> attrs*
+      attrs'* := <desugar-lc-attrs(|rhs*)> attrs*
+
+  desugar-lc-attrs(|rhs*) =
+    innermost(remove-align-list-and-pp-constraints);
+    flatten-list;
+    map(try(desugar-lc-attr(|rhs*)))
 
   desugar-lc-attr(|rhs*):
     LayoutConstraint(constraint) -> LayoutConstraint(constraint')
     where
-      constraint' := <topdown(try(get-tree-position(|rhs*))); topdown(try(rewrite-constraint(|rhs*)))> constraint
+      constraint' := <bottomup(try(get-tree-position(|rhs*) <+ rewrite-constraint(|rhs*)))> constraint
 
   rewrite-constraint(|rhs*):
     Indent(ref-pos, pos*) -> constraint
@@ -387,4 +383,14 @@ rules
   remove-align-list-and-pp-constraints:
     LayoutConstraint(<remove-constraint>) -> []
 
-  remove-constraint = ?AlignList(_) + ?PPAlignList(_) + ?PPOffside(_, _) + ?PPIndent(_, _) + ?PPAlign(_, _) + ?PPNewLineIndent(_, _) + ?PPNewLineIndentBy(_, _, _) + ?PPNewLine(_) + ?PPNewLineBy(_, _)
+  remove-constraint =
+      ?[]
+    + ?AlignList(_)
+    + ?PPAlignList(_)
+    + ?PPOffside(_, _)
+    + ?PPIndent(_, _)
+    + ?PPAlign(_, _)
+    + ?PPNewLineIndent(_, _)
+    + ?PPNewLineIndentBy(_, _, _)
+    + ?PPNewLine(_)
+    + ?PPNewLineBy(_, _)

--- a/org.metaborg.meta.lang.template/trans/analysis/desugar.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/desugar.str
@@ -318,11 +318,11 @@ rules // Layout declarations desugaring
 rules // Util
 
   /**
-   * Combines a list of constraints in a left associative manner.
+   * Combines a list of constraints into `And` in a left associative manner.
    */
   combine-constraints = reverse; combine-constraints-
   combine-constraints-: [x] -> x
-  combine-constraints-: [x | xs] -> And(<combine-constraints> xs, x)
+  combine-constraints-: [x | xs] -> And(<combine-constraints-> xs, x)
     where <not(?[])> xs
 
 

--- a/org.metaborg.meta.lang.template/trans/analysis/desugar.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/desugar.str
@@ -199,19 +199,19 @@ rules
   desugar-layout-constraints(|chars):
     sections* -> sections'*
     where
-      sections'* := <map(desugar-lc-section(|chars) <+ id)> sections*
+      sections'* := <map(try(desugar-lc-section(|chars)))> sections*
 
   desugar-lc-section(|chars):
     SDFSection(ContextFreeSyntax(p*)) -> SDFSection(ContextFreeSyntax([p'*, align-list*]))
     where
       align-list* := <filter(create-productions-align-list(|chars)); flatten-list; nub> p*;
-      p'*         := <map(desugar-lc-prod(|chars)); innermost(remove-align-list-and-pp-constraints); topdown(try(remove-align-list-and-pp-constraints)); topdown(try(flatten-list))> p*
+      p'*         := <map(desugar-lc-prod(|chars)); topdown(repeat(remove-align-list-and-pp-constraints)); topdown(try(flatten-list))> p*
 
   desugar-lc-section(|chars):
     SDFSection(Kernel(p*)) -> SDFSection(Kernel([p'*, align-list*]))
     where
       align-list* := <filter(create-productions-align-list(|chars)); flatten-list; nub> p*;
-      p'*         := <map(desugar-lc-prod(|chars)); topdown(try(remove-align-list-and-pp-constraints)); topdown(try(remove-align-list-and-pp-constraints)); topdown(try(flatten-list))> p*
+      p'*         := <map(desugar-lc-prod(|chars)); topdown(repeat(remove-align-list-and-pp-constraints)); topdown(try(flatten-list))> p*
 
   create-productions-align-list(|chars):
     SdfProduction(lhs, Rhs(rhs*), Attrs(attrs*)) -> prods*
@@ -258,69 +258,61 @@ rules
   desugar-lc-prod(|chars):
     SdfProduction(lhs, Rhs(rhs*), Attrs(attrs*)) -> SdfProduction(lhs, Rhs(rhs*), Attrs(attrs'*))
     where
-      attrs'* := <map(desugar-lc-attr(|rhs*) <+ id)> attrs*
+      attrs'* := <map(try(desugar-lc-attr(|rhs*)))> attrs*
 
   desugar-lc-prod(|chars):
     SdfProductionWithCons(lhs, Rhs(rhs*), Attrs(attrs*)) -> SdfProductionWithCons(lhs, Rhs(rhs*), Attrs(attrs'*))
       where
-      attrs'* := <map(desugar-lc-attr(|rhs*) <+ id)> attrs*
+      attrs'* := <map(try(desugar-lc-attr(|rhs*)))> attrs*
 
   desugar-lc-prod(|chars):
     t@TemplateProduction(lhs, rhs, Attrs(attrs*)) -> TemplateProduction(lhs, rhs, Attrs(attrs'*))
     where
       rhs*    := <get-production-rhs(|chars)> t;
-      attrs'* := <map(desugar-lc-attr(|rhs*) <+ id)> attrs*
+      attrs'* := <map(try(desugar-lc-attr(|rhs*)))> attrs*
 
   desugar-lc-prod(|chars):
     t@TemplateProductionWithCons(lhs, rhs, Attrs(attrs*)) -> TemplateProductionWithCons(lhs, rhs, Attrs(attrs'*))
     where
       rhs*    := <get-production-rhs(|chars)> t;
-      attrs'* := <map(desugar-lc-attr(|rhs*) <+ id)> attrs*
+      attrs'* := <map(try(desugar-lc-attr(|rhs*)))> attrs*
 
   desugar-lc-attr(|rhs*):
     LayoutConstraint(constraint) -> LayoutConstraint(constraint')
     where
-      constraint' := <topdown(try(rewrite-constraint(|rhs*)))> constraint
+      constraint' := <topdown(try(get-tree-position(|rhs*))); topdown(try(rewrite-constraint(|rhs*)))> constraint
 
   rewrite-constraint(|rhs*):
     Indent(ref-pos, pos*) -> constraint
     where
-      ref-pos'   := <get-tree-position(|rhs*)> ref-pos;
-      constraint := <map(get-tree-position(|rhs*); create-indent-constraint(|ref-pos')); flatten-list; combine-constraints> pos*
+      constraint := <map(create-indent-constraint(|ref-pos)); combine-constraints> pos*
 
   rewrite-constraint(|rhs*):
     NewLineIndent(ref-pos, pos*) -> constraint
     where
-      ref-pos'   := <get-tree-position(|rhs*)> ref-pos;
-      constraint := <map(get-tree-position(|rhs*); create-newline-indent-constraint(|ref-pos')); flatten-list; combine-constraints> pos*
+      constraint := <map(create-newline-indent-constraint(|ref-pos)); combine-constraints> pos*
+
+  rewrite-constraint(|rhs*):
+    Offside(ref-pos, []) -> Gt(Col(Left(ref-pos)), Col(First(ref-pos)))
 
   rewrite-constraint(|rhs*):
     Offside(ref-pos, pos*) -> constraint
     where
       <not(?[])> pos*;
-      ref-pos'   := <get-tree-position(|rhs*)> ref-pos;
-      constraint := <map(get-tree-position(|rhs*); create-offside-constraint(|ref-pos')); flatten-list; combine-constraints> pos*
+      constraint := <map(create-offside-constraint(|ref-pos)); combine-constraints> pos*
+
+  rewrite-constraint(|rhs*):
+    Align(ref-pos, pos*) -> constraint
+    where
+      constraint := <map(create-align-constraint(|ref-pos)); combine-constraints> pos*
+
+  combine-constraints:
+    [x] -> x
 
   combine-constraints:
     [x | xs] -> And(x, <combine-constraints> xs)
     where
       <not(?[])> xs
-
-  combine-constraints:
-    [x] -> x
-
-  rewrite-constraint(|rhs*):
-    Offside(ref-pos, pos*) -> Gt(Col(Left(ref-pos')), Col(First(ref-pos')))
-    where
-      <?[]> pos*;
-      ref-pos' := <get-tree-position(|rhs*)> ref-pos
-
-  rewrite-constraint(|rhs*):
-    Align(ref-pos, pos*) -> constraint
-    where
-      <not(?[])> pos*;
-      ref-pos'   := <get-tree-position(|rhs*)> ref-pos;
-      constraint := <map(get-tree-position(|rhs*); create-align-constraint(|ref-pos')); flatten-list; combine-constraints> pos*
 
   get-tree-position(|rhs*):
     PosRef(p) -> PosRef(p)
@@ -379,6 +371,9 @@ rules
 
   remove-align-list-and-pp-constraints:
     Or(c, <remove-constraint>) -> c
+
+  remove-align-list-and-pp-constraints:
+    Not(<remove-constraint>) -> []
 
   remove-align-list-and-pp-constraints:
     LayoutConstraint(<remove-constraint>) -> []

--- a/org.metaborg.meta.lang.template/trans/analysis/desugar.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/desugar.str
@@ -346,7 +346,7 @@ rules
   get-non-terminal-symbol(|rhs*):
     LiteralRef(l) -> symbol
     where
-      symbol := <fetch-elem(?Lit(l))> rhs*
+      symbol := <fetch-elem(?Lit(l) + ?CiLit(l))> rhs*
 
   create-offside-constraint(|ref-pos):
     PosRef(p) -> Gt(Col(Left(PosRef(p))), Col(First(ref-pos)))

--- a/org.metaborg.meta.lang.template/trans/analysis/desugar.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/desugar.str
@@ -261,16 +261,16 @@ rules // Layout declarations desugaring
       attrs' := <desugar-lc-attrs(|rhs)> attrs
 
   desugar-lc-prod(|chars):
-    t@TemplateProduction(lhs, _, Attrs(attrs)) -> TemplateProduction(lhs, rhs, Attrs(attrs'))
+    t@TemplateProduction(lhs, rhs, Attrs(attrs)) -> TemplateProduction(lhs, rhs, Attrs(attrs'))
     where
-      rhs := <get-production-rhs(|chars)> t;
-      attrs' := <desugar-lc-attrs(|rhs)> attrs
+      rhs' := <get-production-rhs(|chars)> t;
+      attrs' := <desugar-lc-attrs(|rhs')> attrs
 
   desugar-lc-prod(|chars):
-    t@TemplateProductionWithCons(lhs, _, Attrs(attrs)) -> TemplateProductionWithCons(lhs, rhs, Attrs(attrs'))
+    t@TemplateProductionWithCons(lhs, rhs, Attrs(attrs)) -> TemplateProductionWithCons(lhs, rhs, Attrs(attrs'))
     where
-      rhs := <get-production-rhs(|chars)> t;
-      attrs' := <desugar-lc-attrs(|rhs)> attrs
+      rhs' := <get-production-rhs(|chars)> t;
+      attrs' := <desugar-lc-attrs(|rhs')> attrs
 
 
   desugar-lc-attrs(|rhs) =

--- a/org.metaborg.meta.lang.template/trans/analysis/desugar.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/desugar.str
@@ -194,44 +194,46 @@ rules
   filter-breaks =
     filter(not(?BreakAngled() + ?BreakSquared()))
 
+
+/********************
+ * Layout Constraints
+ ********************/
 rules
 
-  desugar-layout-constraints(|chars):
-    sections* -> sections'*
-    where
-      sections'* := <map(try(desugar-lc-section(|chars)))> sections*
+  desugar-layout-constraints(|chars): sections -> <map(try(desugar-lc-section(|chars)))> sections
 
-  desugar-lc-section(|chars):
-    SDFSection(ContextFreeSyntax(p*)) -> SDFSection(ContextFreeSyntax(<conc> (p'*, align-list*)))
-    where
-      align-list* := <filter(create-productions-align-list(|chars)); flatten-list; nub> p*;
-      p'*         := <map(desugar-lc-prod(|chars))> p*
+  desugar-lc-section(|chars): SDFSection(ContextFreeSyntax(prods)) ->
+    SDFSection(ContextFreeSyntax(<desugar-lc-prods(|chars)> prods))
 
-  desugar-lc-section(|chars):
-    SDFSection(Kernel(p*)) -> SDFSection(Kernel(<conc> (p'*, align-list*)))
+  desugar-lc-section(|chars): SDFSection(Kernel(prods)) ->
+    SDFSection(Kernel(<desugar-lc-prods(|chars)> prods))
+
+  desugar-lc-prods(|chars): prods -> <conc> (prods', align-prods)
     where
-      align-list* := <filter(create-productions-align-list(|chars)); flatten-list; nub> p*;
-      p'*         := <map(desugar-lc-prod(|chars))> p*
+      align-prods := <filter(create-productions-align-list(|chars)); flatten-list; nub> prods;
+      prods' := <map(desugar-lc-prod(|chars))> prods
+
+rules // Align list desugaring
 
   create-productions-align-list(|chars):
-    SdfProduction(lhs, Rhs(rhs*), Attrs(attrs*)) -> <create-align-productions(|rhs*)> attrs*
+    SdfProduction(_, Rhs(rhs), Attrs(attrs)) -> <create-align-productions(|rhs)> attrs
 
   create-productions-align-list(|chars):
-    SdfProductionWithCons(lhs, Rhs(rhs*), Attrs(attrs*)) -> <create-align-productions(|rhs*)> attrs*
+    SdfProductionWithCons(_, Rhs(rhs), Attrs(attrs)) -> <create-align-productions(|rhs)> attrs
 
   create-productions-align-list(|chars):
-    t@TemplateProduction(lhs, rhs, Attrs(attrs*)) -> <create-align-productions(|rhs*)> attrs*
+    t@TemplateProduction(_, _, Attrs(attrs)) -> <create-align-productions(|rhs)> attrs
     where
-      rhs*  := <get-production-rhs(|chars)> t
+      rhs := <get-production-rhs(|chars)> t
 
   create-productions-align-list(|chars):
-    t@TemplateProductionWithCons(lhs, rhs, Attrs(attrs*)) -> <create-align-productions(|rhs*)> attrs*
+    t@TemplateProductionWithCons(_, _, Attrs(attrs)) -> <create-align-productions(|rhs)> attrs
     where
-      rhs*  := <get-production-rhs(|chars)> t
+      rhs := <get-production-rhs(|chars)> t
 
-  create-align-productions(|rhs*) =
+  create-align-productions(|rhs) =
     collect-all(?AlignList(<id>), conc);
-    map(get-non-terminal-symbol(|rhs*));
+    map(get-non-terminal-symbol(|rhs));
     filter(create-align-production)
 
   create-align-production:
@@ -246,99 +248,117 @@ rules
   create-align-production:
     IterStarSep(s, sep) -> SdfProduction(IterSep(s, sep), Rhs([IterSep(s, sep), sep, s]), Attrs([LayoutConstraint(Eq(Col(First(PosRef("0"))), Col(First(PosRef("2")))))]))
 
+rules // Layout declarations desugaring
+
   desugar-lc-prod(|chars):
-    SdfProduction(lhs, Rhs(rhs*), Attrs(attrs*)) -> SdfProduction(lhs, Rhs(rhs*), Attrs(attrs'*))
+    SdfProduction(lhs, Rhs(rhs), Attrs(attrs)) -> SdfProduction(lhs, Rhs(rhs), Attrs(attrs'))
     where
-      attrs'* := <desugar-lc-attrs(|rhs*)> attrs*
+      attrs' := <desugar-lc-attrs(|rhs)> attrs
 
   desugar-lc-prod(|chars):
-    SdfProductionWithCons(lhs, Rhs(rhs*), Attrs(attrs*)) -> SdfProductionWithCons(lhs, Rhs(rhs*), Attrs(attrs'*))
-      where
-      attrs'* := <desugar-lc-attrs(|rhs*)> attrs*
-
-  desugar-lc-prod(|chars):
-    t@TemplateProduction(lhs, rhs, Attrs(attrs*)) -> TemplateProduction(lhs, rhs, Attrs(attrs'*))
+    SdfProductionWithCons(lhs, Rhs(rhs), Attrs(attrs)) -> SdfProductionWithCons(lhs, Rhs(rhs), Attrs(attrs'))
     where
-      rhs*    := <get-production-rhs(|chars)> t;
-      attrs'* := <desugar-lc-attrs(|rhs*)> attrs*
+      attrs' := <desugar-lc-attrs(|rhs)> attrs
 
   desugar-lc-prod(|chars):
-    t@TemplateProductionWithCons(lhs, rhs, Attrs(attrs*)) -> TemplateProductionWithCons(lhs, rhs, Attrs(attrs'*))
+    t@TemplateProduction(lhs, _, Attrs(attrs)) -> TemplateProduction(lhs, rhs, Attrs(attrs'))
     where
-      rhs*    := <get-production-rhs(|chars)> t;
-      attrs'* := <desugar-lc-attrs(|rhs*)> attrs*
+      rhs := <get-production-rhs(|chars)> t;
+      attrs' := <desugar-lc-attrs(|rhs)> attrs
 
-  desugar-lc-attrs(|rhs*) =
-    innermost(remove-align-list-and-pp-constraints);
+  desugar-lc-prod(|chars):
+    t@TemplateProductionWithCons(lhs, _, Attrs(attrs)) -> TemplateProductionWithCons(lhs, rhs, Attrs(attrs'))
+    where
+      rhs := <get-production-rhs(|chars)> t;
+      attrs' := <desugar-lc-attrs(|rhs)> attrs
+
+
+  desugar-lc-attrs(|rhs) =
+    remove-align-list-and-pp-constraints;
     flatten-list;
-    map(try(desugar-lc-attr(|rhs*)))
+    map(try(desugar-lc-attr(|rhs)))
 
-  desugar-lc-attr(|rhs*):
-    LayoutConstraint(constraint) -> LayoutConstraint(constraint')
+  desugar-lc-attr(|rhs): LayoutConstraint(constraint) -> LayoutConstraint(constraint')
     where
-      constraint' := <bottomup(try(get-tree-position(|rhs*) <+ rewrite-constraint(|rhs*)))> constraint
+      constraint' := <bottomup(try(get-tree-position(|rhs) <+ rewrite-constraint))> constraint
 
-  rewrite-constraint(|rhs*):
-    Indent(ref-pos, pos*) -> constraint
+
+  /**
+   * Rewrites a layout declaration to layout constraints.
+   * It is assumed that all `ConstraintTreeRef` have been desugared to `PosRef`.
+   */
+  rewrite-constraint: Indent(ref-pos, pos*) -> constraint
     where
       constraint := <map(create-indent-constraint(|ref-pos)); combine-constraints> pos*
 
-  rewrite-constraint(|rhs*):
-    NewLineIndent(ref-pos, pos*) -> constraint
+  create-indent-constraint(|ref-pos): PosRef(p) -> Gt(Col(First(PosRef(p))), Col(First(ref-pos)))
+
+  rewrite-constraint: NewLineIndent(ref-pos, pos*) -> constraint
     where
       constraint := <map(create-newline-indent-constraint(|ref-pos)); combine-constraints> pos*
 
-  rewrite-constraint(|rhs*):
-    Offside(ref-pos, []) -> Gt(Col(Left(ref-pos)), Col(First(ref-pos)))
+  create-newline-indent-constraint(|ref-pos): PosRef(p) ->
+    And(Gt(Col(First(PosRef(p))), Col(First(ref-pos))), Gt(Line(First(PosRef(p))), Line(Last(ref-pos))))
 
-  rewrite-constraint(|rhs*):
-    Offside(ref-pos, pos*) -> constraint
+  rewrite-constraint: Offside(ref-pos, []) -> Gt(Col(Left(ref-pos)), Col(First(ref-pos)))
+
+  rewrite-constraint: Offside(ref-pos, pos*) -> constraint
     where
       <not(?[])> pos*;
       constraint := <map(create-offside-constraint(|ref-pos)); combine-constraints> pos*
 
-  rewrite-constraint(|rhs*):
-    Align(ref-pos, pos*) -> constraint
+  create-offside-constraint(|ref-pos): PosRef(p) -> Gt(Col(Left(PosRef(p))), Col(First(ref-pos)))
+
+  rewrite-constraint: Align(ref-pos, pos*) -> constraint
     where
       constraint := <map(create-align-constraint(|ref-pos)); combine-constraints> pos*
 
-  combine-constraints:
-    [x] -> x
+  create-align-constraint(|ref-pos): PosRef(p) -> Eq(Col(First(PosRef(p))), Col(First(ref-pos)))
 
-  combine-constraints:
-    [x | xs] -> And(x, <combine-constraints> xs)
-    where
-      <not(?[])> xs
+rules // Util
 
-  get-tree-position(|rhs*):
-    PosRef(p) -> PosRef(p)
+  /**
+   * Combines a list of constraints in a left associative manner.
+   */
+  combine-constraints = reverse; combine-constraints-
+  combine-constraints-: [x] -> x
+  combine-constraints-: [x | xs] -> And(<combine-constraints> xs, x)
+    where <not(?[])> xs
 
-  get-tree-position(|rhs*):
-    LabelRef(l) -> PosRef(<dec; int-to-string> p)
-    where
-      l' := <strip-annos> l;
-      p := <add-indices; fetch-elem({ i, s: ?(i, s); <where(strip-annos; get-labeled-symbol(|l'))> s; !i})> rhs*
 
-  get-tree-position(|rhs*):
-    LiteralRef(l) -> PosRef(<dec; int-to-string> p)
-    where
-      unquoted := <strip-annos; un-double-quote> l;
-      p := <add-indices; fetch-elem({ i, s: ?(i, s); <where(symbol-is-literal(|unquoted))> s; !i})> rhs*
+  /**
+   * Transforms a ConstraintTreeRef` to a `PosRef`
+   * with zero based index of a symbol in rhs.
+   */
+  get-tree-position(|rhs): PosRef(p) -> PosRef(p)
 
-  get-non-terminal-symbol(|rhs*):
-    PosRef(p) -> <index; try(?Label(_, <id>))> (<string-to-int; inc> p, rhs*)
-
-  get-non-terminal-symbol(|rhs*):
-    LabelRef(l) -> symbol
+  get-tree-position(|rhs): LabelRef(l) -> PosRef(<dec; int-to-string> p)
     where
       l' := <strip-annos> l;
-      symbol := <fetch-elem(strip-annos; get-labeled-symbol(|l'))> rhs*
+      p := <add-indices; fetch-elem({ i, s: ?(i, s); <where(strip-annos; get-labeled-symbol(|l'))> s; !i})> rhs
 
-  get-non-terminal-symbol(|rhs*):
-    LiteralRef(l) -> symbol
+  get-tree-position(|rhs): LiteralRef(l) -> PosRef(<dec; int-to-string> p)
     where
       unquoted := <strip-annos; un-double-quote> l;
-      symbol := <fetch-elem(unwrap-label; where (symbol-is-literal(|unquoted)))> rhs*
+      p := <add-indices; fetch-elem({ i, s: ?(i, s); <where(symbol-is-literal(|unquoted))> s; !i})> rhs
+
+
+  /**
+   * Returns an unlabeled `Symbol` from a `ConstraintTreeRef`.
+   * Fails if the symbol could not be found in rhs.
+   */
+  get-non-terminal-symbol(|rhs): PosRef(p) -> <index; unwrap-label> (<string-to-int; inc> p, rhs)
+
+  get-non-terminal-symbol(|rhs): LabelRef(l) -> symbol
+    where
+      l' := <strip-annos> l;
+      symbol := <fetch-elem(strip-annos; get-labeled-symbol(|l'))> rhs
+
+  get-non-terminal-symbol(|rhs): LiteralRef(l) -> symbol
+    where
+      unquoted := <strip-annos; un-double-quote> l;
+      symbol := <fetch-elem(unwrap-label; where (symbol-is-literal(|unquoted)))> rhs
+
 
   /**
    * Succeeds if a given `Symbol` term is a literal equal to l.
@@ -353,35 +373,17 @@ rules
     where <un-double-quote> str => l
 
 
-  create-offside-constraint(|ref-pos):
-    PosRef(p) -> Gt(Col(Left(PosRef(p))), Col(First(ref-pos)))
-
-  create-indent-constraint(|ref-pos):
-    PosRef(p) -> Gt(Col(First(PosRef(p))), Col(First(ref-pos)))
-
-  create-newline-indent-constraint(|ref-pos):
-    PosRef(p) -> And(Gt(Col(First(PosRef(p))), Col(First(ref-pos))), Gt(Line(First(PosRef(p))), Line(Last(ref-pos))))
-
-  create-align-constraint(|ref-pos):
-    PosRef(p) -> Eq(Col(First(PosRef(p))), Col(First(ref-pos)))
-
-  remove-align-list-and-pp-constraints:
-    And(<remove-constraint>, c) -> c
-
-  remove-align-list-and-pp-constraints:
-    And(c, <remove-constraint>) -> c
-
-  remove-align-list-and-pp-constraints:
-    Or(<remove-constraint>, c) -> c
-
-  remove-align-list-and-pp-constraints:
-    Or(c, <remove-constraint>) -> c
-
-  remove-align-list-and-pp-constraints:
-    Not(<remove-constraint>) -> []
-
-  remove-align-list-and-pp-constraints:
-    LayoutConstraint(<remove-constraint>) -> []
+  /**
+   * Removes all align-list and pp declarations from layout constraints.
+   * Returns the empty list when no layout is left.
+   */
+  remove-align-list-and-pp-constraints = innermost(remove-align-list-and-pp-constraint)
+  remove-align-list-and-pp-constraint: LayoutConstraint(<remove-constraint>) -> []
+  remove-align-list-and-pp-constraint: And(<remove-constraint>, c) -> c
+  remove-align-list-and-pp-constraint: And(c, <remove-constraint>) -> c
+  remove-align-list-and-pp-constraint: Or(<remove-constraint>, c) -> c
+  remove-align-list-and-pp-constraint: Or(c, <remove-constraint>) -> c
+  remove-align-list-and-pp-constraint: Not(<remove-constraint>) -> []
 
   remove-constraint =
       ?[]

--- a/org.metaborg.meta.lang.template/trans/analysis/desugar.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/desugar.str
@@ -318,35 +318,44 @@ rules
     PosRef(p) -> PosRef(p)
 
   get-tree-position(|rhs*):
-    LiteralRef(l) -> PosRef(<dec; int-to-string> p)
-    where
-      p := <get-index> (Lit(l), rhs*)
-
-  get-tree-position(|rhs*):
     LabelRef(l) -> PosRef(<dec; int-to-string> p)
     where
-      l'    := <strip-annos> l;
-      rhs'* := <strip-annos> rhs*;
-      <fetch-elem(?Label(Unquoted(l'), symbol))> rhs'*;
-      p := <get-index> (Label(Unquoted(l'), symbol), rhs'*)
+      l' := <strip-annos> l;
+      p := <add-indices; fetch-elem({ i, s: ?(i, s); <where(strip-annos; get-labeled-symbol(|l'))> s; !i})> rhs*
+
+  get-tree-position(|rhs*):
+    LiteralRef(l) -> PosRef(<dec; int-to-string> p)
+    where
+      unquoted := <strip-annos; un-double-quote> l;
+      p := <add-indices; fetch-elem({ i, s: ?(i, s); <where(symbol-is-literal(|unquoted))> s; !i})> rhs*
 
   get-non-terminal-symbol(|rhs*):
-    PosRef(p) -> <index; ?Label(_, <id>)> (<string-to-int; inc> p, rhs*)
-
-  get-non-terminal-symbol(|rhs*):
-    PosRef(p) -> <index> (<string-to-int; inc> p, rhs*)
+    PosRef(p) -> <index; try(?Label(_, <id>))> (<string-to-int; inc> p, rhs*)
 
   get-non-terminal-symbol(|rhs*):
     LabelRef(l) -> symbol
     where
-      l'    := <strip-annos> l;
-      rhs'* := <strip-annos> rhs*;
-      <fetch-elem(?Label(Unquoted(l'), symbol))> rhs'*
+      l' := <strip-annos> l;
+      symbol := <fetch-elem(strip-annos; get-labeled-symbol(|l'))> rhs*
 
   get-non-terminal-symbol(|rhs*):
     LiteralRef(l) -> symbol
     where
-      symbol := <fetch-elem(?Lit(l) + ?CiLit(l))> rhs*
+      unquoted := <strip-annos; un-double-quote> l;
+      symbol := <fetch-elem(unwrap-label; where (symbol-is-literal(|unquoted)))> rhs*
+
+  /**
+   * Succeeds if a given `Symbol` term is a literal equal to l.
+   * l should be unquoted.
+   */
+  symbol-is-literal(|l) = strip-annos; unwrap-label; (?Lit(<un-double-quote>) + ?CiLit(<un-single-quote>)); ?l
+
+  unwrap-label = try(?Label(_, <id>))
+
+  get-labeled-symbol(|l): Label(Unquoted(l), symbol) -> symbol
+  get-labeled-symbol(|l): Label(Quoted(str), symbol) -> symbol
+    where <un-double-quote> str => l
+
 
   create-offside-constraint(|ref-pos):
     PosRef(p) -> Gt(Col(Left(PosRef(p))), Col(First(ref-pos)))

--- a/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
@@ -182,9 +182,11 @@ rules
     where
       rhs := <get-production-rhs(|chars)> prod;
       attrs := <get-production-attrs> prod;
+      <try(check-for-multiple-layout; create-errors(|ctx))> attrs;
       <try(check-for-pos-ref; create-errors(|ctx))> (rhs, attrs);
       <try(check-for-literals; create-errors(|ctx))> (rhs, attrs);
       <try(check-align-list; create-errors(|ctx))> (rhs, attrs);
+      <try(check-align-list-in-and; create-errors(|ctx))> attrs;
       <try(check-offside; create-errors(|ctx))> (rhs, attrs);
       <try(check-duplicate; create-errors(|ctx))> (rhs, attrs);
       <try(check-order; create-errors(|ctx))> (rhs, attrs);
@@ -202,6 +204,11 @@ rules
   get-production-attrs: SdfProductionWithCons(_, _, Attrs(attrs)) -> attrs
   get-production-attrs: TemplateProduction(_, _, Attrs(attrs)) -> attrs
   get-production-attrs: TemplateProductionWithCons(_, _, Attrs(attrs)) -> attrs
+
+
+  check-for-multiple-layout: attrs -> (invalids, "Cannot have multiple definitions of layout or ignore-layout")
+    where
+      invalids := <collect-all(?LayoutConstraint(_) + ?IgnoreLayout(), conc); ?[_|<id>]; not(?[])> attrs
 
 
   check-for-pos-ref: (rhs, attrs) -> (invalids, "Invalid tree selector - index ouf of bounds")
@@ -230,6 +237,11 @@ rules
       invalids := <filter-invalid-pos(not-iter|rhs)> positions
 
   not-iter = not(?Iter(_) <+ ?IterStar(_) <+ ?IterSep(_, _) <+ ?IterStarSep(_, _))
+
+
+  check-align-list-in-and: attrs -> (invalids, "align-list cannot be used inside '!' or '||'")
+    where
+      invalids := <collect-all(?Or(_, _) + ?Not(_)); collect-all(?AlignList(_), conc); not(?[])> attrs
 
 
   check-offside: (rhs, attrs) -> (invalids, "Invalid tree selector - offside with single argument should be applied to non-terminal")

--- a/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
@@ -247,7 +247,7 @@ rules
   check-offside: (rhs, attrs) -> (invalids, "Invalid tree selector - offside with single argument should be applied to non-terminal")
     where
       positions := <collect-all(?Offside(<id>, []) + ?PPOffside(<id>, []), conc); not(?[])> attrs;
-      invalids := <filter-invalid-pos(?Lit(_)|rhs)> positions
+      invalids := <filter-invalid-pos(?Lit(_) + ?CiLit(_)|rhs)> positions
 
 
   filter-invalid-pos(invalid|rhs) = filter(where(get-non-terminal-symbol(|rhs); invalid))

--- a/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
@@ -223,12 +223,17 @@ rules
 
   check-for-literals: (rhs, attrs) -> (invalids, "Invalid tree selector - undefined or duplicated literal")
     where
-      litRefs := <collect-all(?LiteralRef(<id>), conc)> attrs;
+      litRefs := <collect-all(?LiteralRef(_), conc)> attrs;
       invalids := <filter(is-invalid-lit(|rhs))> litRefs
 
   is-invalid-lit(|rhs): lit -> <id>
     where
-      <not(eq)> (1, <filter(?Lit(lit)); length> rhs)
+      <not(eq)> (1, <get-all-literal-symbols(|rhs); length> lit)
+
+  get-all-literal-symbols(|rhs): LiteralRef(l) -> symbols
+    where
+      unquoted := <strip-annos; un-double-quote> l;
+      symbols := <filter(where(symbol-is-literal(|unquoted)))> rhs
 
 
   check-align-list: (rhs, attrs) -> (invalids, "Invalid tree selector - align-list should be applied to list non-terminal")

--- a/org.metaborg.meta.lang.template/trans/templatelang.str
+++ b/org.metaborg.meta.lang.template/trans/templatelang.str
@@ -115,3 +115,7 @@ rules // Debugging
 
   // analysis-default-debug-interface(msg) = debug(msg)
   // analysis-default-debug-interface = debug
+
+rules  // Testing
+
+  test-desugar-layout-constraints: Module(name, i, sections) -> Module(name, i, <desugar-layout-constraints(|[])> sections)


### PR DESCRIPTION
The desugaring of layout constraints had no tests, so I have written tests for many cases, cleaned up the code and fixed some corner cases.

### Fixes
* `AlignList` and pp constraints were not always correctly removed from constraints
* Added analysis to warn the user of incorrect use of `align-list`, since it can only be used inside `&&` and not `||` and `!`.
* Added analysis to warn the user when using multiple layouts for a single production or using `ignore-layout` as well as `layout`. Multiple layouts should be combined using `&&`
* Add retrieving quoted labels from productions
* Fix unlabeling symbols when getting them from productions
* Add retrieving single quoted literals from productions
* Fix  re-combining constraints in a left associative manner
* Split up redundant code into util strategies