### PR TITLE
Add method State.getGotoId(int productionId, int devaultValue)

### DIFF
--- a/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/query/IProductionToGoto.java
+++ b/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/query/IProductionToGoto.java
@@ -2,14 +2,20 @@ package org.metaborg.parsetable.query;
 
 public interface IProductionToGoto {
 
-    /*
+    /**
      * Whether a goto for the given production id is present.
      */
     boolean contains(int productionId);
 
-    /*
+    /**
      * Get the goto state id for the given production id.
      */
     int get(int productionId);
+
+    /**
+     * Get the goto state id for the given production id,
+     * or the default value if no goto state exists for this production.
+     */
+    int get(int productionId, int defaultValue);
 
 }

--- a/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/query/ProductionToGotoForLoop.java
+++ b/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/query/ProductionToGotoForLoop.java
@@ -31,4 +31,14 @@ public class ProductionToGotoForLoop implements IProductionToGoto {
         throw new IllegalStateException();
     }
 
+    @Override public int get(int productionId, int defaultValue) {
+        for(IGoto gotoAction : gotos) {
+            for(int gotoActionProductionId : gotoAction.productionIds())
+                if(gotoActionProductionId == productionId)
+                    return gotoAction.gotoStateId();
+        }
+
+        return defaultValue;
+    }
+
 }

--- a/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/query/ProductionToGotoJavaHashMap.java
+++ b/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/query/ProductionToGotoJavaHashMap.java
@@ -30,4 +30,8 @@ public class ProductionToGotoJavaHashMap implements IProductionToGoto {
         return productionToGoto.get(productionId);
     }
 
+    @Override public int get(int productionId, int defaultValue) {
+        return productionToGoto.getOrDefault(productionId, defaultValue);
+    }
+
 }

--- a/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/states/IState.java
+++ b/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/states/IState.java
@@ -17,4 +17,6 @@ public interface IState {
 
     int getGotoId(int productionId);
 
+    int getGotoId(int productionId, int defaultValue);
+
 }

--- a/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/states/State.java
+++ b/org.metaborg.parsetable/src/main/java/org/metaborg/parsetable/states/State.java
@@ -54,6 +54,10 @@ public final class State implements IState {
         return productionToGoto.get(productionId);
     }
 
+    @Override public int getGotoId(int productionId, int defaultValue) {
+        return productionToGoto.get(productionId, defaultValue);
+    }
+
     @Override public boolean equals(Object obj) {
         if(!(obj instanceof State))
             return false;

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/parsetable/State.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/parsetable/State.java
@@ -360,6 +360,11 @@ public class State implements IState, Comparable<State>, Serializable {
         return gotosMapping.get(productionId).gotoStateId();
     }
 
+    @Override public int getGotoId(int productionId, int defaultValue) {
+        IGoto iGoto = gotosMapping.get(productionId);
+        return iGoto == null ? defaultValue : iGoto.gotoStateId();
+    }
+
     public void calculateActionsForCharacter() {
         // TODO: this should take into account which states only contain recovery reduces
         actionsForCharacter = new ActionsForCharacterDisjointSorted(readActions(), Collections.emptySet());


### PR DESCRIPTION
Required for metaborg/jsglr#100.

A change in the incremental parser requires retrieving the goto ID of any production on any state, even when the state does not have a goto for that production.

Note that this PR merges to `master`, and includes #56. The full Spoofax build succeeds on my machine™.