### PR TITLE
Feature: added layout constraint single-line

### DIFF
--- a/org.metaborg.meta.lang.template.test/layout-constraints/analysis.spt
+++ b/org.metaborg.meta.lang.template.test/layout-constraints/analysis.spt
@@ -87,3 +87,14 @@ test newline indent undefined literal [[newline-indent [["["]] c]] 1 error at #1
 test newline indent duplicate literal [[newline-indent [["-"]] c]] 1 error at #1
 test newline indent out of bounds index [[newline-indent b [[7]], [[8]] ]] 2 errors at #1, #2
 test newline indent invalid label [[newline-indent [[d]] [[z]] ]] 2 errors at #1, #2
+
+test single-line no args [[single-line]] analysis succeeds
+test single-line one [[single-line l]] analysis succeeds
+test single-line two [[single-line b c]] analysis succeeds
+test single-line twice same [[single-line b [[b]] ]] 1 error at #1
+test single-line more [[ [[single-line l b c]] ]] 1 error at #1
+test single-line single literal [[single-line [[1]] ]] 1 error at #1
+test single-line out of order [[single-line c [[b]] ]] 1 error at #1
+test single-line undefined literal [[single-line [["|"]] ]] 1 error at #1
+test single-line duplicate literal [[single-line "test" [["-"]] ]] 1 error at #1
+test single-line out of bounds [[single-line [[9]] ]] 1 error at #1

--- a/org.metaborg.meta.lang.template.test/layout-constraints/desugar.spt
+++ b/org.metaborg.meta.lang.template.test/layout-constraints/desugar.spt
@@ -275,6 +275,66 @@ B.B = <b>
 B+ = B+ B {layout(0.first.col == 1.first.col)}
 ]]
 
+test desugar single line no args [[
+module desugar
+context-free syntax
+A.A = B {layout(single-line)}
+B.B = <b>
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = B {layout(0.first.line == 0.last.line)}
+B.B = <b>
+]]
+
+test desugar single line no args [[
+module desugar
+context-free syntax
+A.A = B "a" B {layout(single-line)}
+B.B = <b>
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = B "a" B {layout(0.first.line == 2.last.line)}
+B.B = <b>
+]]
+
+test desugar single line one [[
+module desugar
+context-free syntax
+A.A = B "a" b:B {layout(single-line b)}
+B.B = <b>
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = B "a" b:B {layout(2.first.line == 2.last.line)}
+B.B = <b>
+]]
+
+test desugar single line two [[
+module desugar
+context-free syntax
+A.A = <if <B>: <B>> {layout(single-line "if" ":")}
+B.B = <b>
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = <if <B>: <B>> {layout(0.first.line == 2.last.line)}
+B.B = <b>
+]]
+
+test desugar multiple single line two [[
+module desugar
+context-free syntax
+A.A = <if <B> then <B> elif <B>: <B>> {layout(single-line "if" "then" && single-line "elif" ":")}
+B.B = <b>
+]] run test-desugar-layout-constraints to [[
+module desugar
+context-free syntax
+A.A = <if <B> then <B> elif <B>: <B>> {layout(0.first.line == 2.last.line && 4.first.line == 6.last.line)}
+B.B = <b>
+]]
+
 test desugar multiple sections productions [[
 module desugar
 context-free syntax

--- a/org.metaborg.meta.lang.template.test/layout-constraints/syntax.spt
+++ b/org.metaborg.meta.lang.template.test/layout-constraints/syntax.spt
@@ -101,6 +101,16 @@ test newline-indent one [[newline-indent ref other]] parse succeeds
 test newline-indent more [[newline-indent ref other, more]] parse succeeds
 test newline-indent more non-separated [[newline-indent ref other more]] parse fails
 
+test single-line none [[single-line]] parse succeeds
+test single-line one no space [[single-line1]] parse fails
+test single-line one [[single-line 0]] parse succeeds
+test single-line two [[single-line 0 1]] parse succeeds
+test single-line two , separated [[single-line 0, 1]] parse fails
+test single-line two , separated [[single-line 0 1, 2]] parse fails
+test single-line more [[single-line 0 1 2 3]] parse succeeds
+test single-line refs [[single-line a b]] parse succeeds
+test single-line labels [[single-line "a""b"]] parse succeeds
+
 test not declaration [[!offside ref]] parse succeeds
 test declaration and declaration [[align this that && indent that other]] parse succeeds
 test declaration or declaration [[align this that || align this other]] parse succeeds

--- a/org.metaborg.meta.lang.template/syntax/layout-constraints/Layout-Constraints.sdf3
+++ b/org.metaborg.meta.lang.template/syntax/layout-constraints/Layout-Constraints.sdf3
@@ -52,6 +52,7 @@ context-free syntax
   Constraint.Align = <align <ConstraintTreeRef> <{ConstraintTreeRef ", "}+>>
   Constraint.AlignList = <align-list <ConstraintTreeRef>>
   Constraint.NewLineIndent = <newline-indent <ConstraintTreeRef> <{ConstraintTreeRef ", "}+>>
+  Constraint.SingleLine = <single-line <ConstraintTreeRef*>>
 
   Constraint.PPOffside = <pp-offside <ConstraintTreeRef> <{ConstraintTreeRef ", "}*>>
   Constraint.PPIndent = <pp-indent <ConstraintTreeRef> <{ConstraintTreeRef ", "}+>>
@@ -75,4 +76,4 @@ context-free priorities
     Constraint.And >
     Constraint.Or,
 
-    {left: ConstraintExp.Mul ConstraintExp.Div } > {left: ConstraintExp.Add ConstraintExp.Sub}
+    {left: ConstraintExp.Mul ConstraintExp.Div} > {left: ConstraintExp.Add ConstraintExp.Sub}

--- a/org.metaborg.meta.lang.template/trans/analysis/desugar.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/desugar.str
@@ -280,40 +280,46 @@ rules // Layout declarations desugaring
 
   desugar-lc-attr(|rhs): LayoutConstraint(constraint) -> LayoutConstraint(constraint')
     where
-      constraint' := <bottomup(try(get-tree-position(|rhs) <+ rewrite-constraint))> constraint
+      constraint' := <bottomup(try(get-tree-position(|rhs) <+ rewrite-constraint(|rhs)))> constraint
 
 
   /**
    * Rewrites a layout declaration to layout constraints.
    * It is assumed that all `ConstraintTreeRef` have been desugared to `PosRef`.
    */
-  rewrite-constraint: Indent(ref-pos, pos*) -> constraint
+  rewrite-constraint(|rhs): Indent(ref-pos, pos*) -> constraint
     where
       constraint := <map(create-indent-constraint(|ref-pos)); combine-constraints> pos*
 
   create-indent-constraint(|ref-pos): PosRef(p) -> Gt(Col(First(PosRef(p))), Col(First(ref-pos)))
 
-  rewrite-constraint: NewLineIndent(ref-pos, pos*) -> constraint
+  rewrite-constraint(|rhs): NewLineIndent(ref-pos, pos*) -> constraint
     where
       constraint := <map(create-newline-indent-constraint(|ref-pos)); combine-constraints> pos*
 
   create-newline-indent-constraint(|ref-pos): PosRef(p) ->
     And(Gt(Col(First(PosRef(p))), Col(First(ref-pos))), Gt(Line(First(PosRef(p))), Line(Last(ref-pos))))
 
-  rewrite-constraint: Offside(ref-pos, []) -> Gt(Col(Left(ref-pos)), Col(First(ref-pos)))
+  rewrite-constraint(|rhs): Offside(ref-pos, []) -> Gt(Col(Left(ref-pos)), Col(First(ref-pos)))
 
-  rewrite-constraint: Offside(ref-pos, pos*) -> constraint
+  rewrite-constraint(|rhs): Offside(ref-pos, pos*) -> constraint
     where
       <not(?[])> pos*;
       constraint := <map(create-offside-constraint(|ref-pos)); combine-constraints> pos*
 
   create-offside-constraint(|ref-pos): PosRef(p) -> Gt(Col(Left(PosRef(p))), Col(First(ref-pos)))
 
-  rewrite-constraint: Align(ref-pos, pos*) -> constraint
+  rewrite-constraint(|rhs): Align(ref-pos, pos*) -> constraint
     where
       constraint := <map(create-align-constraint(|ref-pos)); combine-constraints> pos*
 
   create-align-constraint(|ref-pos): PosRef(p) -> Eq(Col(First(PosRef(p))), Col(First(ref-pos)))
+
+  rewrite-constraint(|rhs): SingleLine([]) -> Eq(Line(First(PosRef("0"))), Line(Last(PosRef(last))))
+    where last := <length; dec; int-to-string> rhs
+
+  rewrite-constraint(|rhs): SingleLine([p|ps]) -> Eq(Line(First(p)), Line(Last(last)))
+    where last := <last <+ !p> ps
 
 rules // Util
 

--- a/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
@@ -187,9 +187,10 @@ rules
       <try(check-for-literals; create-errors(|ctx))> (rhs, attrs);
       <try(check-align-list; create-errors(|ctx))> (rhs, attrs);
       <try(check-align-list-in-and; create-errors(|ctx))> attrs;
-      <try(check-offside; create-errors(|ctx))> (rhs, attrs);
+      <try(check-single-literal; create-errors(|ctx))> (rhs, attrs);
       <try(check-duplicate; create-errors(|ctx))> (rhs, attrs);
       <try(check-order; create-errors(|ctx))> (rhs, attrs);
+      <try(check-arity-single-line; create-errors(|ctx))> attrs;
       <try(check-irrelevant; create-warnings(|ctx))> (rhs, attrs)
 
 
@@ -249,9 +250,9 @@ rules
       invalids := <collect-all(?Or(_, _) + ?Not(_)); collect-all(?AlignList(_), conc); not(?[])> attrs
 
 
-  check-offside: (rhs, attrs) -> (invalids, "Invalid tree selector - offside with single argument should be applied to non-terminal")
+  check-single-literal: (rhs, attrs) -> (invalids, "Invalid tree selector - declaration with single argument cannot be applied to literal")
     where
-      positions := <collect-all(?Offside(<id>, []) + ?PPOffside(<id>, []), conc); not(?[])> attrs;
+      positions := <collect-all(?Offside(<id>, []) + ?PPOffside(<id>, []) + ?SingleLine([<id>]), conc); not(?[])> attrs;
       invalids := <filter-invalid-pos(?Lit(_) + ?CiLit(_)|rhs)> positions
 
 
@@ -272,6 +273,7 @@ rules
   decls-to-arguments: NewLineIndent(p, ps) -> [p | ps] where <not(?[])> ps
   decls-to-arguments: PPNewLineIndent(p, ps) -> [p | ps] where <not(?[])> ps
   decls-to-arguments: PPNewLineIndentBy(_, p, ps) -> [p | ps] where <not(?[])> ps
+  decls-to-arguments: SingleLine(ps) -> ps where <length; int-gt(|1)> ps
 
   get-duplicate-pos(|rhs): positions -> dups
     where
@@ -293,6 +295,7 @@ rules
       invalids := <map(get-out-of-order(|rhs)); flatten-list> positions
 
   decls-to-pair: Offside(p, ps) -> (p, ps) where <not(?[])> ps
+  decls-to-pair: SingleLine([p|ps]) -> (p, ps) where <not(?[])> ps
   decls-to-pair: PPOffside(p, ps) -> (p, ps) where <not(?[])> ps
   decls-to-pair: NewLineIndent(p, ps) -> (p, ps) where <not(?[])> ps
   decls-to-pair: PPNewLineIndent(p, ps) -> (p, ps) where <not(?[])> ps
@@ -306,6 +309,10 @@ rules
     where
       PosRef(tree) := <get-tree-position(|rhs)> pos
 
+
+  check-arity-single-line: attrs -> (invalids, "Applying single-line to more than two arguments is the same as applying it to the first and last")
+    where
+      invalids := <collect-all({ xs: ?SingleLine(xs); where(<length; int-gt(|2)> xs) }, conc); not(?[])> attrs
 
   check-irrelevant: (rhs, attrs) -> (warnings, "Irrelevant layout constraint, no reference of tree selectors")
     where


### PR DESCRIPTION
This PR adds a new `single-line` layout constraint, which can be used in 3 ways
1. `single-line` without arguments it will constrain the whole production to be on a single line
2. `single-line a` with one argument will constrain the given tree to be on a single line
3. `single-line a b` with two arguments will constrain both trees to be on the same line
The declaration is parsed with a list of arguments, but more than 2 are rejected in analysis, since writing `single-line a b c d` is the same as `single-line a d`. Furthermore, it cannot be applied to a single literal or multiple times to the same tree.
I have also added parse, analysis and desugar tests.