### PR TITLE
Output string SortVar instead of String Sort for lexical syntax

### DIFF
--- a/org.metaborg.meta.lang.template/trans/generation/signatures/to-sig.str
+++ b/org.metaborg.meta.lang.template/trans/generation/signatures/to-sig.str
@@ -63,7 +63,7 @@ rules
       <not(fetch-elem(?Reject()))> a*
 
   lexsort-to-injection:
-    s -> OpDeclInj(FunType([SortType("String")], SortType(s)))
+    s -> OpDeclInj(FunType([SortVar("string")], SortType(s)))
 
   section-to-sig:
     SDFSection(ContextFreeSyntax(p*)) -> <not(?[])> [sig*, cc-sig*, cc-ins-sig*, cc-opt-sig*]


### PR DESCRIPTION
 To be forward compatible with Stratego 2.

Only question is: does anything else depend on the current way of translating lexical syntax sorts to Stratego signatures?