### PR TITLE
Add meta variables to SDF3 Stratego mix syntax test

### DIFF
--- a/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
+++ b/org.metaborg.meta.lang.template/trans/analysis/name-constraints.str
@@ -428,3 +428,17 @@ rules
       where
         <?s> s';
         <eq> (<length> ty*, <length> ty'*)
+
+rules
+
+  nabl-constraint(|ctx):
+      section@VariablesProductive(_) -> <fail>
+  where
+      msg := "The SDF2 variables section is no longer support, please write your own A.meta-var and A.meta-listvar definitions in context-free syntax";
+      <task-create-error(|ctx, msg)> section
+
+  nabl-constraint(|ctx):
+      section@LexVariablesProductive(_) -> <fail>
+  where
+      msg := "The SDF2 variables section is no longer support, please write your own A.meta-var and A.meta-listvar definitions in context-free syntax";
+      <task-create-error(|ctx, msg)> section

--- a/org.metaborg.sdf3.meta.integrationtest/editor/Main.esv
+++ b/org.metaborg.sdf3.meta.integrationtest/editor/Main.esv
@@ -13,8 +13,9 @@ menus
 
   menu: "Transform"
 
-    action: "Swap exps (abstract syntax)"             = editor-action-swap-exps-abstract-syntax             (source)
-    action: "Swap exps (concrete syntax)"             = editor-action-swap-exps-concrete-syntax             (source)
-    action: "Swap exps (concrete syntax simple)"      = editor-action-swap-exps-concrete-syntax-simple      (source)
-    action: "Swap exps (concrete syntax var)"         = editor-action-swap-exps-concrete-syntax-var         (source)
-    action: "Reverse stmts (concrete syntax varlist)" = editor-action-reverse-stmts-concrete-syntax-varlist (source)
+    action: "Swap exps (abstract syntax)"              = editor-action-swap-exps-abstract-syntax              (source)
+    action: "Swap exps (concrete syntax)"              = editor-action-swap-exps-concrete-syntax              (source)
+    action: "Swap exps (concrete syntax simple)"       = editor-action-swap-exps-concrete-syntax-simple       (source)
+    action: "Swap exps (concrete syntax var)"          = editor-action-swap-exps-concrete-syntax-var          (source)
+    action: "Reverse stmts (concrete syntax varlist)"  = editor-action-reverse-stmts-concrete-syntax-varlist  (source)
+    action: "Surround stmts (concrete syntax varlist)" = editor-action-surround-stmts-concrete-syntax-varlist (source)

--- a/org.metaborg.sdf3.meta.integrationtest/editor/Main.esv
+++ b/org.metaborg.sdf3.meta.integrationtest/editor/Main.esv
@@ -16,3 +16,4 @@ menus
     action: "Swap (abstract syntax)"        = swap-editor-abstract-syntax        (source)
     action: "Swap (concrete syntax)"        = swap-editor-concrete-syntax        (source)
     action: "Swap (concrete syntax simple)" = swap-editor-concrete-syntax-simple (source)
+    action: "Swap (concrete syntax var)"    = swap-editor-concrete-syntax-var    (source)

--- a/org.metaborg.sdf3.meta.integrationtest/editor/Main.esv
+++ b/org.metaborg.sdf3.meta.integrationtest/editor/Main.esv
@@ -13,8 +13,8 @@ menus
 
   menu: "Transform"
 
-    action: "Swap (abstract syntax)"        = swap-editor-abstract-syntax        (source)
-    action: "Swap (concrete syntax)"        = swap-editor-concrete-syntax        (source)
-    action: "Swap (concrete syntax simple)" = swap-editor-concrete-syntax-simple (source)
-    action: "Swap (concrete syntax var)"    = swap-editor-concrete-syntax-var    (source)
-    action: "Reverse stmts (concrete syntax varlist)" = reverse-editor-stmts-concrete-syntax-varlist (source)
+    action: "Swap exps (abstract syntax)"             = editor-action-swap-exps-abstract-syntax             (source)
+    action: "Swap exps (concrete syntax)"             = editor-action-swap-exps-concrete-syntax             (source)
+    action: "Swap exps (concrete syntax simple)"      = editor-action-swap-exps-concrete-syntax-simple      (source)
+    action: "Swap exps (concrete syntax var)"         = editor-action-swap-exps-concrete-syntax-var         (source)
+    action: "Reverse stmts (concrete syntax varlist)" = editor-action-reverse-stmts-concrete-syntax-varlist (source)

--- a/org.metaborg.sdf3.meta.integrationtest/editor/Main.esv
+++ b/org.metaborg.sdf3.meta.integrationtest/editor/Main.esv
@@ -17,3 +17,4 @@ menus
     action: "Swap (concrete syntax)"        = swap-editor-concrete-syntax        (source)
     action: "Swap (concrete syntax simple)" = swap-editor-concrete-syntax-simple (source)
     action: "Swap (concrete syntax var)"    = swap-editor-concrete-syntax-var    (source)
+    action: "Reverse stmts (concrete syntax varlist)" = reverse-editor-stmts-concrete-syntax-varlist (source)

--- a/org.metaborg.sdf3.meta.integrationtest/editor/Main.esv
+++ b/org.metaborg.sdf3.meta.integrationtest/editor/Main.esv
@@ -19,3 +19,5 @@ menus
     action: "Swap exps (concrete syntax var)"          = editor-action-swap-exps-concrete-syntax-var          (source)
     action: "Reverse stmts (concrete syntax varlist)"  = editor-action-reverse-stmts-concrete-syntax-varlist  (source)
     action: "Surround stmts (concrete syntax varlist)" = editor-action-surround-stmts-concrete-syntax-varlist (source)
+    action: "Surround stmts 2 (concrete syntax varlist)" = editor-action-surround-stmts-concrete-syntax-varlist2 (source)
+    action: "Surround stmts (concrete syntax list fromterm)" = editor-action-surround-stmts-concrete-syntax-list-fromterm (source)

--- a/org.metaborg.sdf3.meta.integrationtest/syntax/foo.sdf3
+++ b/org.metaborg.sdf3.meta.integrationtest/syntax/foo.sdf3
@@ -25,6 +25,7 @@ context-free syntax
 
   Exp.meta-var = ExpVar
   Stmt+.meta-listvar = StmtListVar
+  Stmt+.Snoc = Stmt+ StmtListVar
 
 lexical sorts
 

--- a/org.metaborg.sdf3.meta.integrationtest/syntax/foo.sdf3
+++ b/org.metaborg.sdf3.meta.integrationtest/syntax/foo.sdf3
@@ -10,6 +10,10 @@ context-free start-symbols
 
   StrategoLang-Module
 
+context-free sorts
+
+  StmtMLV
+
 context-free syntax
 
   StrategoLang-PreTerm.ToTerm = <|[ <Stmt> ]|>
@@ -24,12 +28,26 @@ context-free syntax
 // TODO: support variables section in SDF3 or document this as the way to write Stratego mix syntax
 
   Exp.meta-var = ExpVar
-  Stmt+.meta-listvar = StmtListVar
-  Stmt+.Snoc = Stmt+ StmtListVar
+
+/*
+  Stmt* =            // Nil
+  Stmt* = Stmt+      // (injection)
+  Stmt+ = Stmt       // Ins
+  Stmt+ = Stmt+ Stmt // Snoc
+
+  // Stmt+ = Stmt Stmt+ // (would be Cons)
+  // Stmt+ = Stmt+ Stmt+ {right} // (old Conc rule before Snoc)
+*/
+
+
+  StmtMLV.meta-listvar = StmtListVar
+
+  Stmt+ = StmtMLV
+  Stmt+.Conc = Stmt+ StmtMLV
 
 lexical sorts
 
-  ExpVar
+  ExpVar StmtListVar
 
 lexical syntax
 

--- a/org.metaborg.sdf3.meta.integrationtest/syntax/foo.sdf3
+++ b/org.metaborg.sdf3.meta.integrationtest/syntax/foo.sdf3
@@ -24,7 +24,7 @@ context-free syntax
 // TODO: support variables section in SDF3 or document this as the way to write Stratego mix syntax
 
   Exp.meta-var = ExpVar
-  Stmt+.meta-list-var = StmtListVar
+  Stmt+.meta-listvar = StmtListVar
 
 lexical sorts
 

--- a/org.metaborg.sdf3.meta.integrationtest/syntax/foo.sdf3
+++ b/org.metaborg.sdf3.meta.integrationtest/syntax/foo.sdf3
@@ -15,12 +15,16 @@ context-free syntax
   StrategoLang-PreTerm.ToTerm = <|[ <Stmt> ]|>
   StrategoLang-PreTerm.ToTerm = <stmt |[ <Stmt> ]|>
 
+  StrategoLang-PreTerm.ToTerm = <|[ <Start> ]|>
+  StrategoLang-PreTerm.ToTerm = <program |[ <Start> ]|>
+
   Exp.FromTerm = [~[StrategoLang-Term]]
   Exp.FromTerm = [~exp:[StrategoLang-Term]]
 
 // TODO: support variables section in SDF3 or document this as the way to write Stratego mix syntax
 
   Exp.meta-var = ExpVar
+  Stmt+.meta-list-var = StmtListVar
 
 lexical sorts
 
@@ -29,3 +33,8 @@ lexical sorts
 lexical syntax
 
   ExpVar = 'exp' [0-9]*
+  StmtListVar = 'stmt' [0-9]* '*'
+
+lexical restrictions
+
+  ExpVar -/- [0-9]

--- a/org.metaborg.sdf3.meta.integrationtest/syntax/foo.sdf3
+++ b/org.metaborg.sdf3.meta.integrationtest/syntax/foo.sdf3
@@ -8,13 +8,15 @@ imports
 
 context-free start-symbols
 
-  StrategoLang-Module
+  Module
 
 context-free sorts
 
-  StmtMLV
+  Module StmtListMeta
 
 context-free syntax
+
+  Module = StrategoLang-Module
 
   StrategoLang-PreTerm.ToTerm = <|[ <Stmt> ]|>
   StrategoLang-PreTerm.ToTerm = <stmt |[ <Stmt> ]|>
@@ -24,26 +26,17 @@ context-free syntax
 
   Exp.FromTerm = [~[StrategoLang-Term]]
   Exp.FromTerm = [~exp:[StrategoLang-Term]]
+  
+  StmtListMeta.FromTerm = [~*[StrategoLang-Term]]
 
-// TODO: support variables section in SDF3 or document this as the way to write Stratego mix syntax
+  Stmt+ = StmtListMeta
+  Stmt+.Conc = Stmt+ StmtListMeta
+
+context-free syntax // meta variables
 
   Exp.meta-var = ExpVar
-
-/*
-  Stmt* =            // Nil
-  Stmt* = Stmt+      // (injection)
-  Stmt+ = Stmt       // Ins
-  Stmt+ = Stmt+ Stmt // Snoc
-
-  // Stmt+ = Stmt Stmt+ // (would be Cons)
-  // Stmt+ = Stmt+ Stmt+ {right} // (old Conc rule before Snoc)
-*/
-
-
-  StmtMLV.meta-listvar = StmtListVar
-
-  Stmt+ = StmtMLV
-  Stmt+.Conc = Stmt+ StmtMLV
+  
+  StmtListMeta.meta-listvar = StmtListVar
 
 lexical sorts
 

--- a/org.metaborg.sdf3.meta.integrationtest/syntax/foo.sdf3
+++ b/org.metaborg.sdf3.meta.integrationtest/syntax/foo.sdf3
@@ -17,3 +17,15 @@ context-free syntax
 
   Exp.FromTerm = [~[StrategoLang-Term]]
   Exp.FromTerm = [~exp:[StrategoLang-Term]]
+
+// TODO: support variables section in SDF3 or document this as the way to write Stratego mix syntax
+
+  Exp.meta-var = ExpVar
+
+lexical sorts
+
+  ExpVar
+
+lexical syntax
+
+  ExpVar = 'exp' [0-9]*

--- a/org.metaborg.sdf3.meta.integrationtest/syntax/thesyntax.sdf3
+++ b/org.metaborg.sdf3.meta.integrationtest/syntax/thesyntax.sdf3
@@ -15,7 +15,7 @@ context-free sorts
 
 context-free syntax
 
-  Start.Program = Stmt
+  Start.Program = Stmt+
   Stmt.Stmt = [[Exp];]
   Exp.Add = [[Exp] + [Exp]]
   Exp.Var = VAR

--- a/org.metaborg.sdf3.meta.integrationtest/test/swap.spt
+++ b/org.metaborg.sdf3.meta.integrationtest/test/swap.spt
@@ -14,5 +14,8 @@ test swap [[x + y;]] transform "Transform -> Swap exps (concrete syntax var)"   
 
 test swap [[x; y;]] transform "Transform -> Reverse stmts (concrete syntax varlist)" to [[y; x;]]
 
-// This test will fail due to broken Conc generation, not sure why yet
-test swap [[x;  y;]] transform "Transform -> Surround stmts (concrete syntax varlist)" to [[a; x; y; b;]]
+test swap [[x; y;]] transform "Transform -> Surround stmts (concrete syntax varlist)" to [[a; x; y; b;]]
+
+test swap [[x; y;]] transform "Transform -> Surround stmts 2 (concrete syntax varlist)" to [[y; x; a; x; y; x; y; b; y; x;]]
+
+test swap [[x; y;]] transform "Transform -> Surround stmts (concrete syntax list fromterm)" to [[a; x; y; b;]]

--- a/org.metaborg.sdf3.meta.integrationtest/test/swap.spt
+++ b/org.metaborg.sdf3.meta.integrationtest/test/swap.spt
@@ -15,6 +15,4 @@ test swap [[x + y;]] transform "Transform -> Swap exps (concrete syntax var)"   
 test swap [[x; y;]] transform "Transform -> Reverse stmts (concrete syntax varlist)" to [[y; x;]]
 
 // This test will fail due to broken Conc generation, not sure why yet
-test swap [[x; y;]] transform "Transform -> Surround stmts (concrete syntax varlist)" to [[
-  //a;
-  x; y; a;]]
+test swap [[x; y;]] transform "Transform -> Surround stmts (concrete syntax varlist)" to [[a; x; y; a;]]

--- a/org.metaborg.sdf3.meta.integrationtest/test/swap.spt
+++ b/org.metaborg.sdf3.meta.integrationtest/test/swap.spt
@@ -13,3 +13,8 @@ test swap [[x + y;]] transform "Transform -> Swap exps (concrete syntax simple)"
 test swap [[x + y;]] transform "Transform -> Swap exps (concrete syntax var)"    to [[y + x;]]
 
 test swap [[x; y;]] transform "Transform -> Reverse stmts (concrete syntax varlist)" to [[y; x;]]
+
+// This test will fail due to broken Conc generation, not sure why yet
+test swap [[x; y;]] transform "Transform -> Surround stmts (concrete syntax varlist)" to [[
+  //a;
+  x; y; a;]]

--- a/org.metaborg.sdf3.meta.integrationtest/test/swap.spt
+++ b/org.metaborg.sdf3.meta.integrationtest/test/swap.spt
@@ -15,4 +15,4 @@ test swap [[x + y;]] transform "Transform -> Swap exps (concrete syntax var)"   
 test swap [[x; y;]] transform "Transform -> Reverse stmts (concrete syntax varlist)" to [[y; x;]]
 
 // This test will fail due to broken Conc generation, not sure why yet
-test swap [[x; y;]] transform "Transform -> Surround stmts (concrete syntax varlist)" to [[a; x; y; a;]]
+test swap [[x;  y;]] transform "Transform -> Surround stmts (concrete syntax varlist)" to [[a; x; y; b;]]

--- a/org.metaborg.sdf3.meta.integrationtest/test/swap.spt
+++ b/org.metaborg.sdf3.meta.integrationtest/test/swap.spt
@@ -4,12 +4,12 @@ language sdf3-meta-integrationtest
 
 start symbol Start
 
-test swap [[x + y;]] transform "Transform -> Swap (abstract syntax)"        to [[y + x;]]
+test swap [[x + y;]] transform "Transform -> Swap exps (abstract syntax)"        to [[y + x;]]
 
-test swap [[x + y;]] transform "Transform -> Swap (concrete syntax)"        to [[y + x;]]
+test swap [[x + y;]] transform "Transform -> Swap exps (concrete syntax)"        to [[y + x;]]
 
-test swap [[x + y;]] transform "Transform -> Swap (concrete syntax simple)" to [[y + x;]]
+test swap [[x + y;]] transform "Transform -> Swap exps (concrete syntax simple)" to [[y + x;]]
 
-test swap [[x + y;]] transform "Transform -> Swap (concrete syntax var)"    to [[y + x;]]
+test swap [[x + y;]] transform "Transform -> Swap exps (concrete syntax var)"    to [[y + x;]]
 
 test swap [[x; y;]] transform "Transform -> Reverse stmts (concrete syntax varlist)" to [[y; x;]]

--- a/org.metaborg.sdf3.meta.integrationtest/test/swap.spt
+++ b/org.metaborg.sdf3.meta.integrationtest/test/swap.spt
@@ -11,3 +11,5 @@ test swap [[x + y;]] transform "Transform -> Swap (concrete syntax)"        to [
 test swap [[x + y;]] transform "Transform -> Swap (concrete syntax simple)" to [[y + x;]]
 
 test swap [[x + y;]] transform "Transform -> Swap (concrete syntax var)"    to [[y + x;]]
+
+test swap [[x; y;]] transform "Transform -> Reverse stmts (concrete syntax varlist)" to [[y; x;]]

--- a/org.metaborg.sdf3.meta.integrationtest/test/swap.spt
+++ b/org.metaborg.sdf3.meta.integrationtest/test/swap.spt
@@ -9,3 +9,5 @@ test swap [[x + y;]] transform "Transform -> Swap (abstract syntax)"        to [
 test swap [[x + y;]] transform "Transform -> Swap (concrete syntax)"        to [[y + x;]]
 
 test swap [[x + y;]] transform "Transform -> Swap (concrete syntax simple)" to [[y + x;]]
+
+test swap [[x + y;]] transform "Transform -> Swap (concrete syntax var)"    to [[y + x;]]

--- a/org.metaborg.sdf3.meta.integrationtest/trans/swap.str
+++ b/org.metaborg.sdf3.meta.integrationtest/trans/swap.str
@@ -7,11 +7,12 @@ imports
 
 rules
 
-  editor-action-swap-exps-abstract-syntax             = editor-action(swap-exps-abstract-syntax)
-  editor-action-swap-exps-concrete-syntax             = editor-action(swap-exps-concrete-syntax)
-  editor-action-swap-exps-concrete-syntax-simple      = editor-action(swap-exps-concrete-syntax-simple)
-  editor-action-swap-exps-concrete-syntax-var         = editor-action(swap-exps-concrete-syntax-var)
-  editor-action-reverse-stmts-concrete-syntax-varlist = editor-action(reverse-stmts-concrete-syntax-varlist)
+  editor-action-swap-exps-abstract-syntax              = editor-action(swap-exps-abstract-syntax)
+  editor-action-swap-exps-concrete-syntax              = editor-action(swap-exps-concrete-syntax)
+  editor-action-swap-exps-concrete-syntax-simple       = editor-action(swap-exps-concrete-syntax-simple)
+  editor-action-swap-exps-concrete-syntax-var          = editor-action(swap-exps-concrete-syntax-var)
+  editor-action-reverse-stmts-concrete-syntax-varlist  = editor-action(reverse-stmts-concrete-syntax-varlist)
+  editor-action-surround-stmts-concrete-syntax-varlist = editor-action(surround-stmts-concrete-syntax-varlist)
 
   editor-action(s):
     (_, _, ast, path, _) -> (path, <topdown(try(s))> ast) 
@@ -35,3 +36,9 @@ rules
     |[ stmt1* ]| ->
     |[ stmt2* ]|
   where stmt2* := <reverse> stmt1*
+
+  surround-stmts-concrete-syntax-varlist:
+    |[ stmt1* ]| ->
+    program |[ //a; // adding anything before the meta-listvar breaks parsing
+       stmt1*
+       a; ]|

--- a/org.metaborg.sdf3.meta.integrationtest/trans/swap.str
+++ b/org.metaborg.sdf3.meta.integrationtest/trans/swap.str
@@ -27,5 +27,10 @@ rules
     |[ ~e2 + ~e1 ; ]|
 
   swap-exp-concrete-syntax-var:
-    |[ exp1 + exp2 ; ]| ->
-    |[ exp2 + exp1 ; ]|
+    |[ exp + exp2 ; ]| ->
+    |[ exp2 + exp ; ]|
+
+//  reverse-stmts-concrete:
+//    |[ stmt1* ]| ->
+//    |[ stmt2* ]|
+//  where stmt2* := <reverse> stmt1*

--- a/org.metaborg.sdf3.meta.integrationtest/trans/swap.str
+++ b/org.metaborg.sdf3.meta.integrationtest/trans/swap.str
@@ -30,7 +30,7 @@ rules
     |[ exp + exp2 ; ]| ->
     |[ exp2 + exp ; ]|
 
-//  reverse-stmts-concrete:
-//    |[ stmt1* ]| ->
-//    |[ stmt2* ]|
-//  where stmt2* := <reverse> stmt1*
+  reverse-stmts-concrete:
+    |[ stmt1* ]| ->
+    |[ stmt2* ]|
+  where stmt2* := <reverse> stmt1*

--- a/org.metaborg.sdf3.meta.integrationtest/trans/swap.str
+++ b/org.metaborg.sdf3.meta.integrationtest/trans/swap.str
@@ -13,6 +13,8 @@ rules
   editor-action-swap-exps-concrete-syntax-var          = editor-action(swap-exps-concrete-syntax-var)
   editor-action-reverse-stmts-concrete-syntax-varlist  = editor-action(reverse-stmts-concrete-syntax-varlist)
   editor-action-surround-stmts-concrete-syntax-varlist = editor-action(surround-stmts-concrete-syntax-varlist)
+  editor-action-surround-stmts-concrete-syntax-varlist2 = editor-action(surround-stmts-concrete-syntax-varlist2)
+  editor-action-surround-stmts-concrete-syntax-list-fromterm = editor-action(surround-stmts-concrete-syntax-list-fromterm)
 
   editor-action(s):
     (_, _, ast, path, _) -> (path, <oncetd(s)> ast) 
@@ -40,3 +42,14 @@ rules
   surround-stmts-concrete-syntax-varlist:
     |[ stmt1* ]|  ->
     program |[ a; stmt1* b; ]|
+  where stmt2* := <reverse> stmt1*
+
+  surround-stmts-concrete-syntax-varlist2:
+    |[ stmt1* ]|  ->
+    program |[ stmt2* a; stmt1* stmt1* b; stmt2* ]|
+  where stmt2* := <reverse> stmt1*
+
+  surround-stmts-concrete-syntax-list-fromterm:
+    |[ ~*stmt1* ]|  ->
+    program |[ a; ~*stmt1* b; ]|
+  where stmt2* := <reverse> stmt1*

--- a/org.metaborg.sdf3.meta.integrationtest/trans/swap.str
+++ b/org.metaborg.sdf3.meta.integrationtest/trans/swap.str
@@ -15,7 +15,7 @@ rules
   editor-action-surround-stmts-concrete-syntax-varlist = editor-action(surround-stmts-concrete-syntax-varlist)
 
   editor-action(s):
-    (_, _, ast, path, _) -> (path, <topdown(try(s))> ast) 
+    (_, _, ast, path, _) -> (path, <oncetd(s)> ast) 
 
   swap-exps-abstract-syntax:
     Add(e1, e2) -> Add(e2, e1)
@@ -38,5 +38,5 @@ rules
   where stmt2* := <reverse> stmt1*
 
   surround-stmts-concrete-syntax-varlist:
-    |[ stmt1* ]| ->
-    program |[ a; stmt1* a; ]|
+    |[ stmt1* ]|  ->
+    program |[ a; stmt1* b; ]|

--- a/org.metaborg.sdf3.meta.integrationtest/trans/swap.str
+++ b/org.metaborg.sdf3.meta.integrationtest/trans/swap.str
@@ -11,6 +11,7 @@ rules
   swap-editor-concrete-syntax        = swap-editor(swap-exp-concrete-syntax|)
   swap-editor-concrete-syntax-simple = swap-editor(swap-exp-concrete-syntax-simple|)
   swap-editor-concrete-syntax-var    = swap-editor(swap-exp-concrete-syntax-var|)
+  reverse-editor-stmts-concrete-syntax-varlist = swap-editor(reverse-stmts-concrete|)
 
   swap-editor(swap-exp|):
     (_, _, ast, path, _) -> (path, <topdown(try(swap-exp))> ast) 

--- a/org.metaborg.sdf3.meta.integrationtest/trans/swap.str
+++ b/org.metaborg.sdf3.meta.integrationtest/trans/swap.str
@@ -39,6 +39,4 @@ rules
 
   surround-stmts-concrete-syntax-varlist:
     |[ stmt1* ]| ->
-    program |[ //a; // adding anything before the meta-listvar breaks parsing
-       stmt1*
-       a; ]|
+    program |[ a; stmt1* a; ]|

--- a/org.metaborg.sdf3.meta.integrationtest/trans/swap.str
+++ b/org.metaborg.sdf3.meta.integrationtest/trans/swap.str
@@ -7,31 +7,31 @@ imports
 
 rules
 
-  swap-editor-abstract-syntax        = swap-editor(swap-exp-abstract-syntax|)
-  swap-editor-concrete-syntax        = swap-editor(swap-exp-concrete-syntax|)
-  swap-editor-concrete-syntax-simple = swap-editor(swap-exp-concrete-syntax-simple|)
-  swap-editor-concrete-syntax-var    = swap-editor(swap-exp-concrete-syntax-var|)
-  reverse-editor-stmts-concrete-syntax-varlist = swap-editor(reverse-stmts-concrete|)
+  editor-action-swap-exps-abstract-syntax             = editor-action(swap-exps-abstract-syntax)
+  editor-action-swap-exps-concrete-syntax             = editor-action(swap-exps-concrete-syntax)
+  editor-action-swap-exps-concrete-syntax-simple      = editor-action(swap-exps-concrete-syntax-simple)
+  editor-action-swap-exps-concrete-syntax-var         = editor-action(swap-exps-concrete-syntax-var)
+  editor-action-reverse-stmts-concrete-syntax-varlist = editor-action(reverse-stmts-concrete-syntax-varlist)
 
-  swap-editor(swap-exp|):
-    (_, _, ast, path, _) -> (path, <topdown(try(swap-exp))> ast) 
+  editor-action(s):
+    (_, _, ast, path, _) -> (path, <topdown(try(s))> ast) 
 
-  swap-exp-abstract-syntax:
+  swap-exps-abstract-syntax:
     Add(e1, e2) -> Add(e2, e1)
 
-  swap-exp-concrete-syntax:
+  swap-exps-concrete-syntax:
     stmt |[ ~exp:e1 + ~exp:e2 ; ]| ->
     stmt |[ ~exp:e2 + ~exp:e1 ; ]|
 
-  swap-exp-concrete-syntax-simple:
+  swap-exps-concrete-syntax-simple:
     |[ ~e1 + ~e2 ; ]| ->
     |[ ~e2 + ~e1 ; ]|
 
-  swap-exp-concrete-syntax-var:
+  swap-exps-concrete-syntax-var:
     |[ exp + exp2 ; ]| ->
     |[ exp2 + exp ; ]|
 
-  reverse-stmts-concrete:
+  reverse-stmts-concrete-syntax-varlist:
     |[ stmt1* ]| ->
     |[ stmt2* ]|
   where stmt2* := <reverse> stmt1*

--- a/org.metaborg.sdf3.meta.integrationtest/trans/swap.str
+++ b/org.metaborg.sdf3.meta.integrationtest/trans/swap.str
@@ -10,6 +10,7 @@ rules
   swap-editor-abstract-syntax        = swap-editor(swap-exp-abstract-syntax|)
   swap-editor-concrete-syntax        = swap-editor(swap-exp-concrete-syntax|)
   swap-editor-concrete-syntax-simple = swap-editor(swap-exp-concrete-syntax-simple|)
+  swap-editor-concrete-syntax-var    = swap-editor(swap-exp-concrete-syntax-var|)
 
   swap-editor(swap-exp|):
     (_, _, ast, path, _) -> (path, <topdown(try(swap-exp))> ast) 
@@ -24,3 +25,7 @@ rules
   swap-exp-concrete-syntax-simple:
     |[ ~e1 + ~e2 ; ]| ->
     |[ ~e2 + ~e1 ; ]|
+
+  swap-exp-concrete-syntax-var:
+    |[ exp1 + exp2 ; ]| ->
+    |[ exp2 + exp1 ; ]|

--- a/sdf3.stratego2.integrationtest/.gitignore
+++ b/sdf3.stratego2.integrationtest/.gitignore
@@ -1,0 +1,14 @@
+/.cache
+/bin
+/src-gen
+/target
+
+/.classpath
+/.project
+/.settings
+/.factorypath
+
+/.polyglot.metaborg.yaml
+
+/trans/foo.tbl
+/trans/table-foo.bin

--- a/sdf3.stratego2.integrationtest/.mvn/extensions.xml
+++ b/sdf3.stratego2.integrationtest/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+  <extension>
+    <groupId>org.metaborg</groupId>
+    <artifactId>spoofax-maven-plugin-pomless</artifactId>
+    <version>2.6.0-SNAPSHOT</version>
+  </extension>
+</extensions>

--- a/sdf3.stratego2.integrationtest/editor/Main.esv
+++ b/sdf3.stratego2.integrationtest/editor/Main.esv
@@ -4,7 +4,7 @@ language
 
   extensions : s3mit
 
-//  provider : target/metaborg/stratego.ctree
+  provider : target/metaborg/stratego.jar
 
   table         : target/metaborg/sdf.tbl
   start symbols : Start

--- a/sdf3.stratego2.integrationtest/editor/Main.esv
+++ b/sdf3.stratego2.integrationtest/editor/Main.esv
@@ -1,0 +1,23 @@
+module Main
+
+language
+
+  extensions : s3mit
+
+//  provider : target/metaborg/stratego.ctree
+
+  table         : target/metaborg/sdf.tbl
+  start symbols : Start
+
+menus
+
+  menu: "Transform"
+
+    action: "Swap exps (abstract syntax)"              = editor-action-swap-exps-abstract-syntax              (source)
+    action: "Swap exps (concrete syntax)"              = editor-action-swap-exps-concrete-syntax              (source)
+    action: "Swap exps (concrete syntax simple)"       = editor-action-swap-exps-concrete-syntax-simple       (source)
+    action: "Swap exps (concrete syntax var)"          = editor-action-swap-exps-concrete-syntax-var          (source)
+    action: "Reverse stmts (concrete syntax varlist)"  = editor-action-reverse-stmts-concrete-syntax-varlist  (source)
+    action: "Surround stmts (concrete syntax varlist)" = editor-action-surround-stmts-concrete-syntax-varlist (source)
+    action: "Surround stmts 2 (concrete syntax varlist)" = editor-action-surround-stmts-concrete-syntax-varlist2 (source)
+    action: "Surround stmts (concrete syntax list fromterm)" = editor-action-surround-stmts-concrete-syntax-list-fromterm (source)

--- a/sdf3.stratego2.integrationtest/metaborg.yaml
+++ b/sdf3.stratego2.integrationtest/metaborg.yaml
@@ -1,6 +1,7 @@
 ---
 id: org.metaborg:sdf3.stratego2.integrationtest:2.6.0-SNAPSHOT
 name: sdf3-stratego2-integrationtest
+metaborgVersion: 2.5.22 # temporary fix for bug in 2.5.22, remove once 2.5.23 is released
 dependencies:
   compile:
   - org.metaborg:org.metaborg.meta.lang.esv:${metaborgVersion}

--- a/sdf3.stratego2.integrationtest/metaborg.yaml
+++ b/sdf3.stratego2.integrationtest/metaborg.yaml
@@ -1,0 +1,39 @@
+---
+id: org.metaborg:sdf3.stratego2.integrationtest:2.6.0-SNAPSHOT
+name: sdf3-stratego2-integrationtest
+dependencies:
+  compile:
+  - org.metaborg:org.metaborg.meta.lang.esv:${metaborgVersion}
+  - org.metaborg:org.metaborg.meta.lang.template:${metaborgVersion}
+  - org.metaborg:org.metaborg.meta.lang.spt:${metaborgVersion}
+  - org.metaborg:stratego.lang:${metaborgVersion}
+  source:
+  - org.metaborg:meta.lib.spoofax:${metaborgVersion}
+  - org.metaborg:stratego.lang:${metaborgVersion}
+  - org.metaborg:strategolib:${metaborgVersion}
+pardonedLanguages:
+- EditorService
+- Stratego-Sugar
+- SDF
+language:
+  sdf:
+    pretty-print: sdf3-stratego2-integrationtest
+    version: sdf3
+    sdf2table: java
+    sdf-meta:
+     - foo
+    placeholder:
+      prefix: "$"
+  stratego:
+    format: jar
+    args:
+    - -la
+    - stratego-sglr
+    - -la
+    - stratego-xtc
+    - -la
+    - stratego-aterm
+    - -la
+    - stratego-sdf
+    - -la
+    - strc

--- a/sdf3.stratego2.integrationtest/metaborg.yaml
+++ b/sdf3.stratego2.integrationtest/metaborg.yaml
@@ -1,17 +1,22 @@
 ---
 id: org.metaborg:sdf3.stratego2.integrationtest:2.6.0-SNAPSHOT
 name: sdf3-stratego2-integrationtest
-metaborgVersion: 2.5.22 # temporary fix for bug in 2.5.22, remove once 2.5.23 is released
 dependencies:
   compile:
   - org.metaborg:org.metaborg.meta.lang.esv:${metaborgVersion}
   - org.metaborg:org.metaborg.meta.lang.template:${metaborgVersion}
   - org.metaborg:org.metaborg.meta.lang.spt:${metaborgVersion}
+  # Workaround to get Stratego 2 dialect to register before trans/swap.str2 is parsed
+  - org.metaborg:org.metaborg.meta.lang.stratego:${metaborgVersion}
   - org.metaborg:stratego.lang:${metaborgVersion}
   source:
   - org.metaborg:meta.lib.spoofax:${metaborgVersion}
   - org.metaborg:stratego.lang:${metaborgVersion}
   - org.metaborg:strategolib:${metaborgVersion}
+  - org.metaborg:gpp:${metaborgVersion}
+  java:
+  - org.metaborg:strategolib:${metaborgVersion}
+  - org.metaborg:gpp:${metaborgVersion}
 pardonedLanguages:
 - EditorService
 - Stratego-Sugar

--- a/sdf3.stratego2.integrationtest/pom.xml
+++ b/sdf3.stratego2.integrationtest/pom.xml
@@ -25,10 +25,22 @@
     </dependency>
     <dependency>
       <groupId>org.metaborg</groupId>
+      <artifactId>org.metaborg.meta.lang.template</artifactId>
+      <version>${metaborg-version}</version>
+      <type>spoofax-language</type>
+    </dependency>
+    <dependency>
+      <groupId>org.metaborg</groupId>
       <artifactId>org.metaborg.meta.lang.spt</artifactId>
       <version>${metaborg-version}</version>
       <type>spoofax-language</type>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.metaborg</groupId>
+      <artifactId>stratego.lang</artifactId>
+      <version>${metaborg-version}</version>
+      <type>spoofax-language</type>
     </dependency>
 
     <!-- source -->
@@ -38,6 +50,18 @@
       <version>${metaborg-version}</version>
       <type>spoofax-language</type>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.metaborg</groupId>
+      <artifactId>strategolib</artifactId>
+      <version>${metaborg-version}</version>
+      <type>spoofax-language</type>
+    </dependency>
+    <dependency>
+      <groupId>org.metaborg</groupId>
+      <artifactId>gpp</artifactId>
+      <version>${metaborg-version}</version>
+      <type>spoofax-language</type>
     </dependency>
   </dependencies>
   

--- a/sdf3.stratego2.integrationtest/pom.xml
+++ b/sdf3.stratego2.integrationtest/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>sdf3.stratego2.integrationtest</artifactId>
+  <packaging>spoofax-language</packaging>
+
+  <parent>
+    <groupId>org.metaborg</groupId>
+    <artifactId>parent.language</artifactId>
+    <version>2.6.0-SNAPSHOT</version>
+    <relativePath>../../releng/parent/java</relativePath>
+  </parent>
+  
+  <dependencies>
+    <!-- compile -->
+    <dependency>
+      <groupId>org.metaborg</groupId>
+      <artifactId>org.metaborg.meta.lang.esv</artifactId>
+      <version>${metaborg-version}</version>
+      <type>spoofax-language</type>
+    </dependency>
+    <dependency>
+      <groupId>org.metaborg</groupId>
+      <artifactId>org.metaborg.meta.lang.spt</artifactId>
+      <version>${metaborg-version}</version>
+      <type>spoofax-language</type>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- source -->
+    <dependency>
+      <groupId>org.metaborg</groupId>
+      <artifactId>meta.lib.spoofax</artifactId>
+      <version>${metaborg-version}</version>
+      <type>spoofax-language</type>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.metaborg</groupId>
+        <artifactId>spoofax-maven-plugin</artifactId>
+        <version>${metaborg-version}</version>
+        <executions>
+          <execution>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <languageUnderTest>org.metaborg:sdf3.stratego2.integrationtest:${metaborg-version}</languageUnderTest>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/sdf3.stratego2.integrationtest/syntax/foo.sdf3
+++ b/sdf3.stratego2.integrationtest/syntax/foo.sdf3
@@ -13,7 +13,7 @@ context-free start-symbols
 
 context-free sorts
   
-  Module StmtListMeta
+  Module
 
 context-free syntax
 
@@ -25,16 +25,13 @@ context-free syntax
   Exp.FromTerm = [~[StrategoLang-Term]]
   Exp.FromTerm = [~exp:[StrategoLang-Term]]
   
-  StmtListMeta.FromTerm = [~*[StrategoLang-Term]]
-
-  Stmt+ = StmtListMeta
-  Stmt+.Conc = Stmt+ StmtListMeta
+  Stmt.FromTerm = [~[StrategoLang-Term]]
 
 context-free syntax // meta variables
 
   Exp.meta-var = ExpVar
-  
-  StmtListMeta.meta-listvar = StmtListVar
+
+  Stmt.meta-listvar = StmtListVar
 
 lexical sorts
 
@@ -44,8 +41,9 @@ lexical syntax
 
   ExpVar = 'exp' [0-9]*
   StmtListVar = 'stmt' [0-9]* '*'
-  Var = ExpVar {reject}
+  VAR = ExpVar {reject}
 
 lexical restrictions
 
   ExpVar -/- [0-9]
+  

--- a/sdf3.stratego2.integrationtest/syntax/foo.sdf3
+++ b/sdf3.stratego2.integrationtest/syntax/foo.sdf3
@@ -3,6 +3,7 @@ module foo
 imports
 
   StrategoLang/import-namespaced
+  StrategoLang/core/modules-namespaced
   StrategoLang/sugar/terms-namespaced
   thesyntax
 

--- a/sdf3.stratego2.integrationtest/syntax/foo.sdf3
+++ b/sdf3.stratego2.integrationtest/syntax/foo.sdf3
@@ -1,0 +1,50 @@
+module foo
+
+imports
+
+  StrategoLang/import-namespaced
+  StrategoLang/sugar/terms-namespaced
+  thesyntax
+
+context-free start-symbols
+
+  Module
+
+context-free sorts
+  
+  Module StmtListMeta
+
+context-free syntax
+
+  Module = StrategoLang-Module
+
+  StrategoLang-PreTerm.ToTerm = <|[ <Stmt> ]|>
+  StrategoLang-PreTerm.ToTerm = <stmt |[ <Stmt> ]|>
+  StrategoLang-PreTerm.ToTerm = <program |[ <Start> ]|>
+
+  Exp.FromTerm = [~[StrategoLang-Term]]
+  Exp.FromTerm = [~exp:[StrategoLang-Term]]
+  
+  StmtListMeta.FromTerm = [~*[StrategoLang-Term]]
+
+  Stmt+ = StmtListMeta
+  Stmt+.Conc = Stmt+ StmtListMeta
+
+context-free syntax // meta variables
+
+  Exp.meta-var = ExpVar
+  
+  StmtListMeta.meta-listvar = StmtListVar
+
+lexical sorts
+
+  ExpVar StmtListVar
+
+lexical syntax
+
+  ExpVar = 'exp' [0-9]*
+  StmtListVar = 'stmt' [0-9]* '*'
+
+lexical restrictions
+
+  ExpVar -/- [0-9]

--- a/sdf3.stratego2.integrationtest/syntax/foo.sdf3
+++ b/sdf3.stratego2.integrationtest/syntax/foo.sdf3
@@ -18,7 +18,6 @@ context-free syntax
 
   Module = StrategoLang-Module
 
-  StrategoLang-PreTerm.ToTerm = <|[ <Stmt> ]|>
   StrategoLang-PreTerm.ToTerm = <stmt |[ <Stmt> ]|>
   StrategoLang-PreTerm.ToTerm = <program |[ <Start> ]|>
 
@@ -44,6 +43,7 @@ lexical syntax
 
   ExpVar = 'exp' [0-9]*
   StmtListVar = 'stmt' [0-9]* '*'
+  Var = ExpVar {reject}
 
 lexical restrictions
 

--- a/sdf3.stratego2.integrationtest/syntax/sdf3-stratego2-integrationtest.sdf3
+++ b/sdf3.stratego2.integrationtest/syntax/sdf3-stratego2-integrationtest.sdf3
@@ -1,0 +1,8 @@
+module sdf3-stratego2-integrationtest
+
+imports
+  thesyntax
+
+context-free start-symbols
+
+  Start

--- a/sdf3.stratego2.integrationtest/syntax/thesyntax.sdf3
+++ b/sdf3.stratego2.integrationtest/syntax/thesyntax.sdf3
@@ -1,0 +1,21 @@
+module thesyntax
+
+lexical sorts
+  VAR
+
+lexical syntax
+  LAYOUT = [\t\ \n\r]
+  VAR = [a-z]+
+
+context-free restrictions
+  LAYOUT? -/- [\ \t\n\r]
+
+context-free sorts
+  Start Stmt Exp
+
+context-free syntax
+
+  Start.Program = Stmt+
+  Stmt.Stmt = [[Exp];]
+  Exp.Add = [[Exp] + [Exp]]
+  Exp.Var = VAR

--- a/sdf3.stratego2.integrationtest/test/swap.spt
+++ b/sdf3.stratego2.integrationtest/test/swap.spt
@@ -1,0 +1,21 @@
+module swap
+
+language sdf3-stratego2-integrationtest
+
+start symbol Start
+
+test swap [[x + y;]] transform "Transform -> Swap (abstract syntax)"        to [[y + x;]]
+
+test swap [[x + y;]] transform "Transform -> Swap (concrete syntax)"        to [[y + x;]]
+
+test swap [[x + y;]] transform "Transform -> Swap (concrete syntax simple)" to [[y + x;]]
+
+test swap [[x + y;]] transform "Transform -> Swap exps (concrete syntax var)"    to [[y + x;]]
+
+test swap [[x; y;]] transform "Transform -> Reverse stmts (concrete syntax varlist)" to [[y; x;]]
+
+test swap [[x; y;]] transform "Transform -> Surround stmts (concrete syntax varlist)" to [[a; x; y; b;]]
+
+test swap [[x; y;]] transform "Transform -> Surround stmts 2 (concrete syntax varlist)" to [[y; x; a; x; y; x; y; b; y; x;]]
+
+test swap [[x; y;]] transform "Transform -> Surround stmts (concrete syntax list fromterm)" to [[a; x; y; b;]]

--- a/sdf3.stratego2.integrationtest/test/swap.spt
+++ b/sdf3.stratego2.integrationtest/test/swap.spt
@@ -4,11 +4,11 @@ language sdf3-stratego2-integrationtest
 
 start symbol Start
 
-test swap [[x + y;]] transform "Transform -> Swap (abstract syntax)"        to [[y + x;]]
+test swap [[x + y;]] transform "Transform -> Swap exps (abstract syntax)"        to [[y + x;]]
 
-test swap [[x + y;]] transform "Transform -> Swap (concrete syntax)"        to [[y + x;]]
+test swap [[x + y;]] transform "Transform -> Swap exps (concrete syntax)"        to [[y + x;]]
 
-test swap [[x + y;]] transform "Transform -> Swap (concrete syntax simple)" to [[y + x;]]
+test swap [[x + y;]] transform "Transform -> Swap exps (concrete syntax simple)" to [[y + x;]]
 
 test swap [[x + y;]] transform "Transform -> Swap exps (concrete syntax var)"    to [[y + x;]]
 

--- a/sdf3.stratego2.integrationtest/trans/pp.str2
+++ b/sdf3.stratego2.integrationtest/trans/pp.str2
@@ -1,0 +1,52 @@
+module pp
+
+imports
+  strategolib
+
+imports
+
+  gpp
+  libspoofax/sdf/pp
+  libspoofax/editor/refactoring/-
+  pp/sdf3-stratego2-integrationtest-parenthesize
+  pp/sdf3-stratego2-integrationtest-pp
+
+rules
+  editor-format :: ? * ? * ? * string * string -> string * ?
+  editor-format:
+    (node, _, ast, path, project-path) -> (filename, result)
+    with
+      ext      := <get-extension> path
+    ; filename := <guarantee-extension(|$[pp.[ext]])> path
+    ; result   := <pp-debug> node
+
+rules
+  
+  pp-sdf3-stratego2-integrationtest-string =
+    parenthesize-sdf3-stratego2-integrationtest
+    ; prettyprint-sdf3-stratego2-integrationtest-start-symbols
+    ; !V([], <id>)
+    ; box2text-string(|120)
+      
+  pp-partial-sdf3-stratego2-integrationtest-string =
+    parenthesize-sdf3-stratego2-integrationtest
+    ; prettyprint-sdf3-stratego2-integrationtest
+    ; !V([], <id>)
+    ; box2text-string(|120)
+    
+  pp-partial-sdf3-stratego2-integrationtest-string(|sort) =
+    parenthesize-sdf3-stratego2-integrationtest
+    ; prettyprint-sdf3-stratego2-integrationtest(|sort)
+    ; !V([], <id>)
+    ; box2text-string(|120)  
+      
+  pp-debug :
+    ast -> result
+    with
+       result := <pp-sdf3-stratego2-integrationtest-string> ast
+    <+ <bottomup(try(not(is-string); not(is-list); not(pp-sdf3-stratego2-integrationtest-string); debug(!"cannot pp ")))> ast
+    ;  result := ""
+
+rules
+  
+  construct-textual-change = construct-textual-change(pp-partial-sdf3-stratego2-integrationtest-string, parenthesize, override-reconstruction, resugar)

--- a/sdf3.stratego2.integrationtest/trans/sdf3_stratego2_integrationtest.str2
+++ b/sdf3.stratego2.integrationtest/trans/sdf3_stratego2_integrationtest.str2
@@ -1,0 +1,5 @@
+module sdf3_stratego2_integrationtest
+
+imports
+
+  swap

--- a/sdf3.stratego2.integrationtest/trans/sdf3_stratego2_integrationtest.str2
+++ b/sdf3.stratego2.integrationtest/trans/sdf3_stratego2_integrationtest.str2
@@ -3,3 +3,5 @@ module sdf3_stratego2_integrationtest
 imports
 
   swap
+  completion/completion
+  pp

--- a/sdf3.stratego2.integrationtest/trans/swap.analyzed.aterm
+++ b/sdf3.stratego2.integrationtest/trans/swap.analyzed.aterm
@@ -1,0 +1,734 @@
+Module(
+  "swap"
+, [ Imports([Import("strategolib"), ImportWildcard("signatures")])
+  , Signature(
+      [ Constructors(
+          [ OpDecl(
+              "Conc"
+            , FunType(
+                [ ConstType(Sort("List", [SortVar("a")]))
+                , ConstType(Sort("List", [SortVar("a")]))
+                ]
+              , ConstType(Sort("List", [SortVar("a")]))
+              )
+            )
+          ]
+        )
+      ]
+    )
+  , Rules(
+      [ DefHasType(
+          "swap-editor-abstract-syntax"
+        , FunTType(
+            []
+          , []
+          , FunNoArgsType(
+              Sort(
+                "Tuple"
+              , [ DynT(Dyn())
+                , DynT(Dyn())
+                , DynT(Dyn())
+                , DynT(Dyn())
+                , DynT(Dyn())
+                ]
+              )
+            , Sort("Tuple", [DynT(Dyn()), DynT(Dyn())])
+            )
+          )
+        )
+      , SDefNoArgs(
+          "swap-editor-abstract-syntax"
+        , CallT(
+            SVar("editor-action")
+          , [ Seq(
+                TypeTest(Sort("Exp", []))
+              , CallT(SVar("swap-exps-abstract-syntax"), [], [])
+              )
+            ]
+          , []
+          )
+        )
+      , DefHasType(
+          "swap-editor-concrete-syntax"
+        , FunTType(
+            []
+          , []
+          , FunNoArgsType(
+              Sort(
+                "Tuple"
+              , [ DynT(Dyn())
+                , DynT(Dyn())
+                , DynT(Dyn())
+                , DynT(Dyn())
+                , DynT(Dyn())
+                ]
+              )
+            , Sort("Tuple", [DynT(Dyn()), DynT(Dyn())])
+            )
+          )
+        )
+      , SDefNoArgs(
+          "swap-editor-concrete-syntax"
+        , CallT(
+            SVar("editor-action")
+          , [ Seq(
+                TypeTest(Sort("Stmt", []))
+              , CallT(SVar("swap-exps-concrete-syntax"), [], [])
+              )
+            ]
+          , []
+          )
+        )
+      , DefHasType(
+          "swap-editor-concrete-syntax-simple"
+        , FunTType(
+            []
+          , []
+          , FunNoArgsType(
+              Sort(
+                "Tuple"
+              , [ DynT(Dyn())
+                , DynT(Dyn())
+                , DynT(Dyn())
+                , DynT(Dyn())
+                , DynT(Dyn())
+                ]
+              )
+            , Sort("Tuple", [DynT(Dyn()), DynT(Dyn())])
+            )
+          )
+        )
+      , SDefNoArgs(
+          "swap-editor-concrete-syntax-simple"
+        , CallT(
+            SVar("editor-action")
+          , [ Seq(
+                TypeTest(Sort("Stmt", []))
+              , CallT(SVar("swap-exps-concrete-syntax-simple"), [], [])
+              )
+            ]
+          , []
+          )
+        )
+      , DefHasType(
+          "swap-editor-concrete-syntax-var"
+        , FunTType(
+            []
+          , []
+          , FunNoArgsType(
+              Sort(
+                "Tuple"
+              , [ DynT(Dyn())
+                , DynT(Dyn())
+                , DynT(Dyn())
+                , DynT(Dyn())
+                , DynT(Dyn())
+                ]
+              )
+            , Sort("Tuple", [DynT(Dyn()), DynT(Dyn())])
+            )
+          )
+        )
+      , SDefNoArgs(
+          "swap-editor-concrete-syntax-var"
+        , CallT(
+            SVar("editor-action")
+          , [ Seq(
+                TypeTest(Sort("Stmt", []))
+              , CallT(SVar("swap-exps-concrete-syntax-var"), [], [])
+              )
+            ]
+          , []
+          )
+        )
+      , DefHasType(
+          "reverse-editor-concrete-syntax-varlist"
+        , FunTType(
+            []
+          , []
+          , FunNoArgsType(
+              Sort(
+                "Tuple"
+              , [ DynT(Dyn())
+                , DynT(Dyn())
+                , DynT(Dyn())
+                , DynT(Dyn())
+                , DynT(Dyn())
+                ]
+              )
+            , Sort("Tuple", [DynT(Dyn()), DynT(Dyn())])
+            )
+          )
+        )
+      , SDefNoArgs(
+          "reverse-editor-concrete-syntax-varlist"
+        , CallT(
+            SVar("editor-action")
+          , [ Seq(
+                TypeTest(Sort("Start", []))
+              , CallT(SVar("reverse-stmts-concrete-syntax-varlist"), [], [])
+              )
+            ]
+          , []
+          )
+        )
+      , DefHasType(
+          "surround-editor-concrete-syntax-varlist"
+        , FunTType(
+            []
+          , []
+          , FunNoArgsType(
+              Sort(
+                "Tuple"
+              , [ DynT(Dyn())
+                , DynT(Dyn())
+                , DynT(Dyn())
+                , DynT(Dyn())
+                , DynT(Dyn())
+                ]
+              )
+            , Sort("Tuple", [DynT(Dyn()), DynT(Dyn())])
+            )
+          )
+        )
+      , SDefNoArgs(
+          "surround-editor-concrete-syntax-varlist"
+        , CallT(
+            SVar("editor-action")
+          , [ Seq(
+                TypeTest(Sort("Start", []))
+              , CallT(SVar("surround-stmts-concrete-syntax-varlist"), [], [])
+              )
+            ]
+          , []
+          )
+        )
+      , DefHasType(
+          "editor-action"
+        , FunTType(
+            [FunTType([], [], FunNoArgsType(DynT(Dyn()), DynT(Dyn())))]
+          , []
+          , FunNoArgsType(
+              Sort(
+                "Tuple"
+              , [ SortVar("a")
+                , SortVar("b")
+                , DynT(Dyn())
+                , SortVar("d")
+                , SortVar("e")
+                ]
+              )
+            , Sort("Tuple", [SortVar("d"), DynT(Dyn())])
+            )
+          )
+        )
+      , RDefT(
+          "editor-action"
+        , [DefaultVarDec("swap-exp")]
+        , []
+        , Rule(
+            NoAnnoList(
+              Tuple(
+                [Wld(), Wld(), Var("ast"), Var("path"), Wld()]
+              )
+            )
+          , NoAnnoList(
+              Tuple(
+                [ Var("path")
+                , App(
+                    CallT(SVar("oncetd"), [CallNoArgs(SVar("swap-exp"))], [])
+                  , Var("ast")
+                  )
+                ]
+              )
+            )
+          , []
+          )
+        )
+      , DefHasType(
+          "swap-exps-abstract-syntax"
+        , FunTType(
+            []
+          , []
+          , FunNoArgsType(Sort("Exp", []), Sort("Exp", []))
+          )
+        )
+      , RDefNoArgs(
+          "swap-exps-abstract-syntax"
+        , Rule(
+            NoAnnoList(Op("Add", [Var("e1"), Var("e2")]))
+          , NoAnnoList(Op("Add", [Var("e2"), Var("e1")]))
+          , []
+          )
+        )
+      , DefHasType(
+          "swap-exps-concrete-syntax"
+        , FunTType(
+            []
+          , []
+          , FunNoArgsType(Sort("Stmt", []), Sort("Stmt", []))
+          )
+        )
+      , RDefNoArgs(
+          "swap-exps-concrete-syntax"
+        , Rule(
+            NoAnnoList(
+              Op(
+                "Stmt"
+              , [NoAnnoList(Op("Add", [Var("e1"), Var("e2")]))]
+              )
+            )
+          , NoAnnoList(
+              Op(
+                "Stmt"
+              , [NoAnnoList(Op("Add", [Var("e2"), Var("e1")]))]
+              )
+            )
+          , []
+          )
+        )
+      , DefHasType(
+          "swap-exps-concrete-syntax-simple"
+        , FunTType(
+            []
+          , []
+          , FunNoArgsType(Sort("Stmt", []), Sort("Stmt", []))
+          )
+        )
+      , RDefNoArgs(
+          "swap-exps-concrete-syntax-simple"
+        , Rule(
+            NoAnnoList(
+              Op(
+                "Stmt"
+              , [NoAnnoList(Op("Add", [Var("e1"), Var("e2")]))]
+              )
+            )
+          , NoAnnoList(
+              Op(
+                "Stmt"
+              , [NoAnnoList(Op("Add", [Var("e2"), Var("e1")]))]
+              )
+            )
+          , []
+          )
+        )
+      , DefHasType(
+          "swap-exps-concrete-syntax-var"
+        , FunTType(
+            []
+          , []
+          , FunNoArgsType(Sort("Stmt", []), Sort("Stmt", []))
+          )
+        )
+      , RDefNoArgs(
+          "swap-exps-concrete-syntax-var"
+        , Rule(
+            NoAnnoList(
+              Op(
+                "Stmt"
+              , [NoAnnoList(Op("Add", [Var("exp"), Var("exp2")]))]
+              )
+            )
+          , NoAnnoList(
+              Op(
+                "Stmt"
+              , [NoAnnoList(Op("Add", [Var("exp2"), Var("exp")]))]
+              )
+            )
+          , []
+          )
+        )
+      , DefHasType(
+          "reverse-stmts-abstract-syntax"
+        , FunTType(
+            []
+          , []
+          , FunNoArgsType(Sort("Start", []), Sort("Start", []))
+          )
+        )
+      , RDefNoArgs(
+          "reverse-stmts-abstract-syntax"
+        , Rule(
+            NoAnnoList(Op("Program", [Var(ListVar("stmt1*"))]))
+          , NoAnnoList(Op("Program", [Var(ListVar("stmt2*"))]))
+          , [ WhereClause(
+                Assign(
+                  Var(ListVar("stmt2*"))
+                , App(
+                    Seq(
+                      TypeTest(Sort("List", [Sort("Stmt", [])]))
+                    , CallT(SVar("reverse"), [], [])
+                    )
+                  , Var(ListVar("stmt1*"))
+                  )
+                )
+              )
+            ]
+          )
+        )
+      , DefHasType(
+          "reverse-stmts-concrete-syntax-varlist"
+        , FunTType(
+            []
+          , []
+          , FunNoArgsType(Sort("Start", []), Sort("Start", []))
+          )
+        )
+      , RDefNoArgs(
+          "reverse-stmts-concrete-syntax-varlist"
+        , Rule(
+            NoAnnoList(
+              Op(
+                "Program"
+              , [ NoAnnoList(
+                    Op(
+                      "Cons"
+                    , [Var(ListVar("stmt1*")), NoAnnoList(Op("Nil", []))]
+                    )
+                  )
+                ]
+              )
+            )
+          , NoAnnoList(
+              Op(
+                "Program"
+              , [ NoAnnoList(
+                    Op(
+                      "Cons"
+                    , [Var(ListVar("stmt2*")), NoAnnoList(Op("Nil", []))]
+                    )
+                  )
+                ]
+              )
+            )
+          , [ WhereClause(
+                Assign(
+                  Var(ListVar("stmt2*"))
+                , App(
+                    Seq(
+                      TypeTest(Sort("List", [Sort("Stmt", [])]))
+                    , CallT(SVar("reverse"), [], [])
+                    )
+                  , Var(ListVar("stmt1*"))
+                  )
+                )
+              )
+            ]
+          )
+        )
+      , DefHasType(
+          "surround-stmts-abstract-syntax"
+        , FunTType(
+            []
+          , []
+          , FunNoArgsType(Sort("Start", []), Sort("Start", []))
+          )
+        )
+      , RDefNoArgs(
+          "surround-stmts-abstract-syntax"
+        , Rule(
+            NoAnnoList(Op("Program", [Var(ListVar("stmt1*"))]))
+          , NoAnnoList(
+              Op(
+                "Program"
+              , [ NoAnnoList(
+                    List(
+                      [ NoAnnoList(
+                          Op(
+                            "Stmt"
+                          , [NoAnnoList(Op("Var", [NoAnnoList(Str("\"a\""))]))]
+                          )
+                        )
+                      , Var(ListVar("stmt1*"))
+                      , NoAnnoList(
+                          Op(
+                            "Stmt"
+                          , [NoAnnoList(Op("Var", [NoAnnoList(Str("\"b\""))]))]
+                          )
+                        )
+                      ]
+                    )
+                  )
+                ]
+              )
+            )
+          , []
+          )
+        )
+      , DefHasType(
+          "surround-stmts-concrete-syntax-varlist"
+        , FunTType(
+            []
+          , []
+          , FunNoArgsType(Sort("Start", []), Sort("Start", []))
+          )
+        )
+      , RDefNoArgs(
+          "surround-stmts-concrete-syntax-varlist"
+        , Rule(
+            NoAnnoList(
+              Op(
+                "Program"
+              , [ NoAnnoList(
+                    Op(
+                      "Cons"
+                    , [Var(ListVar("stmt1*")), NoAnnoList(Op("Nil", []))]
+                    )
+                  )
+                ]
+              )
+            )
+          , NoAnnoList(
+              Op(
+                "Program"
+              , [ NoAnnoList(
+                    Op(
+                      "Cons"
+                    , [ NoAnnoList(
+                          Op(
+                            "Conc"
+                          , [ NoAnnoList(
+                                Op(
+                                  "Stmt"
+                                , [NoAnnoList(Op("Var", [NoAnnoList(Str("a"))]))]
+                                )
+                              )
+                            , Var(ListVar("stmt1*"))
+                            ]
+                          )
+                        )
+                      , NoAnnoList(
+                          Op(
+                            "Cons"
+                          , [ NoAnnoList(
+                                Op(
+                                  "Stmt"
+                                , [NoAnnoList(Op("Var", [NoAnnoList(Str("b"))]))]
+                                )
+                              )
+                            , NoAnnoList(Op("Nil", []))
+                            ]
+                          )
+                        )
+                      ]
+                    )
+                  )
+                ]
+              )
+            )
+          , []
+          )
+        )
+      , DefHasType(
+          "surround-stmts-abstract-syntax2"
+        , FunTType(
+            []
+          , []
+          , FunNoArgsType(Sort("Start", []), Sort("Start", []))
+          )
+        )
+      , RDefNoArgs(
+          "surround-stmts-abstract-syntax2"
+        , Rule(
+            NoAnnoList(Op("Program", [Var(ListVar("stmt1*"))]))
+          , NoAnnoList(
+              Op(
+                "Program"
+              , [ NoAnnoList(
+                    List(
+                      [ Var(ListVar("stmt2*"))
+                      , NoAnnoList(
+                          Op(
+                            "Stmt"
+                          , [NoAnnoList(Op("Var", [NoAnnoList(Str("\"a\""))]))]
+                          )
+                        )
+                      , Var(ListVar("stmt1*"))
+                      , Var(ListVar("stmt1*"))
+                      , NoAnnoList(
+                          Op(
+                            "Stmt"
+                          , [NoAnnoList(Op("Var", [NoAnnoList(Str("\"b\""))]))]
+                          )
+                        )
+                      , Var(ListVar("stmt2*"))
+                      ]
+                    )
+                  )
+                ]
+              )
+            )
+          , [ WhereClause(
+                Assign(
+                  Var(ListVar("stmt2*"))
+                , App(
+                    Seq(
+                      TypeTest(Sort("List", [Sort("Stmt", [])]))
+                    , CallT(SVar("reverse"), [], [])
+                    )
+                  , Var(ListVar("stmt1*"))
+                  )
+                )
+              )
+            ]
+          )
+        )
+      , DefHasType(
+          "surround-stmts-concrete-syntax-varlist2"
+        , FunTType(
+            []
+          , []
+          , FunNoArgsType(Sort("Start", []), Sort("Start", []))
+          )
+        )
+      , RDefNoArgs(
+          "surround-stmts-concrete-syntax-varlist2"
+        , Rule(
+            NoAnnoList(
+              Op(
+                "Program"
+              , [ NoAnnoList(
+                    Op(
+                      "Cons"
+                    , [Var(ListVar("stmt1*")), NoAnnoList(Op("Nil", []))]
+                    )
+                  )
+                ]
+              )
+            )
+          , NoAnnoList(
+              Op(
+                "Program"
+              , [ NoAnnoList(
+                    Op(
+                      "Conc"
+                    , [ NoAnnoList(
+                          Op(
+                            "Conc"
+                          , [ NoAnnoList(
+                                Op(
+                                  "Conc"
+                                , [ Var(ListVar("stmt2*"))
+                                  , NoAnnoList(
+                                      Op(
+                                        "Stmt"
+                                      , [NoAnnoList(Op("Var", [NoAnnoList(Str("a"))]))]
+                                      )
+                                    )
+                                  , Var(ListVar("stmt1*"))
+                                  ]
+                                )
+                              )
+                            , Var(ListVar("stmt1*"))
+                            ]
+                          )
+                        )
+                      , NoAnnoList(
+                          Op(
+                            "Stmt"
+                          , [NoAnnoList(Op("Var", [NoAnnoList(Str("b"))]))]
+                          )
+                        )
+                      , Var(ListVar("stmt2*"))
+                      ]
+                    )
+                  )
+                ]
+              )
+            )
+          , [ WhereClause(
+                Assign(
+                  Var(ListVar("stmt2*"))
+                , App(
+                    Seq(
+                      TypeTest(Sort("List", [Sort("Stmt", [])]))
+                    , CallT(SVar("reverse"), [], [])
+                    )
+                  , Var(ListVar("stmt1*"))
+                  )
+                )
+              )
+            ]
+          )
+        )
+      , DefHasType(
+          "surround-stmts-concrete-syntax-list-fromterm"
+        , FunTType(
+            []
+          , []
+          , FunNoArgsType(Sort("Start", []), Sort("Start", []))
+          )
+        )
+      , RDefNoArgs(
+          "surround-stmts-concrete-syntax-list-fromterm"
+        , Rule(
+            NoAnnoList(
+              Op(
+                "Program"
+              , [ NoAnnoList(
+                    Op(
+                      "Cons"
+                    , [Var(ListVar("stmt1*")), NoAnnoList(Op("Nil", []))]
+                    )
+                  )
+                ]
+              )
+            )
+          , NoAnnoList(
+              Op(
+                "Program"
+              , [ NoAnnoList(
+                    Op(
+                      "Cons"
+                    , [ NoAnnoList(
+                          Op(
+                            "Conc"
+                          , [ NoAnnoList(
+                                Op(
+                                  "Stmt"
+                                , [NoAnnoList(Op("Var", [NoAnnoList(Str("a"))]))]
+                                )
+                              )
+                            , Var(ListVar("stmt1*"))
+                            ]
+                          )
+                        )
+                      , NoAnnoList(
+                          Op(
+                            "Cons"
+                          , [ NoAnnoList(
+                                Op(
+                                  "Stmt"
+                                , [NoAnnoList(Op("Var", [NoAnnoList(Str("b"))]))]
+                                )
+                              )
+                            , NoAnnoList(Op("Nil", []))
+                            ]
+                          )
+                        )
+                      ]
+                    )
+                  )
+                ]
+              )
+            )
+          , [ WhereClause(
+                Assign(
+                  Var(ListVar("stmt2*"))
+                , App(
+                    Seq(
+                      TypeTest(Sort("List", [Sort("Stmt", [])]))
+                    , CallT(SVar("reverse"), [], [])
+                    )
+                  , Var(ListVar("stmt1*"))
+                  )
+                )
+              )
+            ]
+          )
+        )
+      ]
+    )
+  ]
+)

--- a/sdf3.stratego2.integrationtest/trans/swap.aterm
+++ b/sdf3.stratego2.integrationtest/trans/swap.aterm
@@ -1,0 +1,284 @@
+Module(
+  "swap"
+, [ Imports([Import("strategolib"), ImportWildcard("signatures")])
+  , Rules(
+      [ DefHasTypeNoArgs(
+          "swap-editor-abstract-syntax"
+        , FunNoArgsType(
+            TupleT(
+              DynT(Dyn())
+            , [DynT(Dyn()), DynT(Dyn()), DynT(Dyn()), DynT(Dyn())]
+            )
+          , TupleT(DynT(Dyn()), [DynT(Dyn())])
+          )
+        )
+      , SDefNoArgs(
+          "swap-editor-abstract-syntax"
+        , CallT(
+            SVar("editor-action")
+          , [Seq(TypeTest(SortNoArgs("Exp")), CallNoArgs(SVar("swap-exps-abstract-syntax")))]
+          , []
+          )
+        )
+      , DefHasTypeNoArgs(
+          "swap-editor-concrete-syntax"
+        , FunNoArgsType(
+            TupleT(
+              DynT(Dyn())
+            , [DynT(Dyn()), DynT(Dyn()), DynT(Dyn()), DynT(Dyn())]
+            )
+          , TupleT(DynT(Dyn()), [DynT(Dyn())])
+          )
+        )
+      , SDefNoArgs(
+          "swap-editor-concrete-syntax"
+        , CallT(
+            SVar("editor-action")
+          , [Seq(TypeTest(SortNoArgs("Stmt")), CallNoArgs(SVar("swap-exps-concrete-syntax")))]
+          , []
+          )
+        )
+      , DefHasTypeNoArgs(
+          "swap-editor-concrete-syntax-simple"
+        , FunNoArgsType(
+            TupleT(
+              DynT(Dyn())
+            , [DynT(Dyn()), DynT(Dyn()), DynT(Dyn()), DynT(Dyn())]
+            )
+          , TupleT(DynT(Dyn()), [DynT(Dyn())])
+          )
+        )
+      , SDefNoArgs(
+          "swap-editor-concrete-syntax-simple"
+        , CallT(
+            SVar("editor-action")
+          , [Seq(TypeTest(SortNoArgs("Stmt")), CallNoArgs(SVar("swap-exps-concrete-syntax-simple")))]
+          , []
+          )
+        )
+      , DefHasTypeNoArgs(
+          "swap-editor-concrete-syntax-var"
+        , FunNoArgsType(
+            TupleT(
+              DynT(Dyn())
+            , [DynT(Dyn()), DynT(Dyn()), DynT(Dyn()), DynT(Dyn())]
+            )
+          , TupleT(DynT(Dyn()), [DynT(Dyn())])
+          )
+        )
+      , SDefNoArgs(
+          "swap-editor-concrete-syntax-var"
+        , CallT(
+            SVar("editor-action")
+          , [Seq(TypeTest(SortNoArgs("Stmt")), CallNoArgs(SVar("swap-exps-concrete-syntax-var")))]
+          , []
+          )
+        )
+      , DefHasTypeNoArgs(
+          "reverse-editor-concrete-syntax-varlist"
+        , FunNoArgsType(
+            TupleT(
+              DynT(Dyn())
+            , [DynT(Dyn()), DynT(Dyn()), DynT(Dyn()), DynT(Dyn())]
+            )
+          , TupleT(DynT(Dyn()), [DynT(Dyn())])
+          )
+        )
+      , SDefNoArgs(
+          "reverse-editor-concrete-syntax-varlist"
+        , CallT(
+            SVar("editor-action")
+          , [Seq(TypeTest(SortNoArgs("Start")), CallNoArgs(SVar("reverse-stmts-concrete-syntax-varlist")))]
+          , []
+          )
+        )
+      , DefHasTypeNoArgs(
+          "surround-editor-concrete-syntax-varlist"
+        , FunNoArgsType(
+            TupleT(
+              DynT(Dyn())
+            , [DynT(Dyn()), DynT(Dyn()), DynT(Dyn()), DynT(Dyn())]
+            )
+          , TupleT(DynT(Dyn()), [DynT(Dyn())])
+          )
+        )
+      , SDefNoArgs(
+          "surround-editor-concrete-syntax-varlist"
+        , CallT(
+            SVar("editor-action")
+          , [Seq(TypeTest(SortNoArgs("Start")), CallNoArgs(SVar("surround-stmts-concrete-syntax-varlist")))]
+          , []
+          )
+        )
+      , DefHasTType(
+          "editor-action"
+        , [FunNoArgsType(DynT(Dyn()), DynT(Dyn()))]
+        , []
+        , FunNoArgsType(
+            TupleT(
+              SortVar("a")
+            , [SortVar("b"), DynT(Dyn()), SortVar("d"), SortVar("e")]
+            )
+          , TupleT(SortVar("d"), [DynT(Dyn())])
+          )
+        )
+      , RDefT(
+          "editor-action"
+        , [DefaultVarDec("swap-exp")]
+        , []
+        , Rule(
+            NoAnnoList(
+              Tuple(
+                [Wld(), Wld(), Var("ast"), Var("path"), Wld()]
+              )
+            )
+          , NoAnnoList(
+              Tuple(
+                [ Var("path")
+                , App(
+                    Call(SVar("oncetd"), [CallNoArgs(SVar("swap-exp"))])
+                  , Var("ast")
+                  )
+                ]
+              )
+            )
+          , []
+          )
+        )
+      , DefHasTypeNoArgs("swap-exps-abstract-syntax", FunNoArgsType(SortNoArgs("Exp"), SortNoArgs("Exp")))
+      , RDefNoArgs(
+          "swap-exps-abstract-syntax"
+        , Rule(
+            NoAnnoList(Op("Add", [Var("e1"), Var("e2")]))
+          , NoAnnoList(Op("Add", [Var("e2"), Var("e1")]))
+          , []
+          )
+        )
+      , DefHasTypeNoArgs("swap-exps-concrete-syntax", FunNoArgsType(SortNoArgs("Stmt"), SortNoArgs("Stmt")))
+      , RDefNoArgs(
+          "swap-exps-concrete-syntax"
+        , Rule(
+            NoAnnoList(
+              ToTerm(
+                Stmt(Add(FromTerm(Var("e1")), FromTerm(Var("e2"))))
+              )
+            )
+          , NoAnnoList(
+              ToTerm(
+                Stmt(Add(FromTerm(Var("e2")), FromTerm(Var("e1"))))
+              )
+            )
+          , []
+          )
+        )
+      , DefHasTypeNoArgs("swap-exps-concrete-syntax-simple", FunNoArgsType(SortNoArgs("Stmt"), SortNoArgs("Stmt")))
+      , RDefNoArgs(
+          "swap-exps-concrete-syntax-simple"
+        , Rule(
+            NoAnnoList(
+              ToTerm(
+                Stmt(Add(FromTerm(Var("e1")), FromTerm(Var("e2"))))
+              )
+            )
+          , NoAnnoList(
+              ToTerm(
+                Stmt(Add(FromTerm(Var("e2")), FromTerm(Var("e1"))))
+              )
+            )
+          , []
+          )
+        )
+      , DefHasTypeNoArgs("swap-exps-concrete-syntax-var", FunNoArgsType(SortNoArgs("Stmt"), SortNoArgs("Stmt")))
+      , RDefNoArgs(
+          "swap-exps-concrete-syntax-var"
+        , Rule(
+            NoAnnoList(ToTerm(Stmt(Add(meta-var("exp"), meta-var("exp2")))))
+          , NoAnnoList(ToTerm(Stmt(Add(meta-var("exp2"), meta-var("exp")))))
+          , []
+          )
+        )
+      , DefHasTypeNoArgs("reverse-stmts-concrete-syntax-varlist", FunNoArgsType(SortNoArgs("Start"), SortNoArgs("Start")))
+      , RDefNoArgs(
+          "reverse-stmts-concrete-syntax-varlist"
+        , Rule(
+            NoAnnoList(ToTerm(Program([meta-listvar("stmt1*")])))
+          , NoAnnoList(ToTerm(Program([meta-listvar("stmt2*")])))
+          , [ WhereClause(
+                Assign(
+                  Var(ListVar("stmt2*"))
+                , App(CallNoArgs(SVar("reverse")), Var(ListVar("stmt1*")))
+                )
+              )
+            ]
+          )
+        )
+      , DefHasTypeNoArgs("surround-stmts-concrete-syntax-varlist", FunNoArgsType(SortNoArgs("Start"), SortNoArgs("Start")))
+      , RDefNoArgs(
+          "surround-stmts-concrete-syntax-varlist"
+        , Rule(
+            NoAnnoList(ToTerm(Program([meta-listvar("stmt1*")])))
+          , NoAnnoList(
+              ToTerm(
+                Program(
+                  [Stmt(Var("a")), meta-listvar("stmt1*"), Stmt(Var("b"))]
+                )
+              )
+            )
+          , []
+          )
+        )
+      , DefHasTypeNoArgs("surround-stmts-concrete-syntax-varlist2", FunNoArgsType(SortNoArgs("Start"), SortNoArgs("Start")))
+      , RDefNoArgs(
+          "surround-stmts-concrete-syntax-varlist2"
+        , Rule(
+            NoAnnoList(ToTerm(Program([meta-listvar("stmt1*")])))
+          , NoAnnoList(
+              ToTerm(
+                Program(
+                  [ meta-listvar("stmt2*")
+                  , Stmt(Var("a"))
+                  , meta-listvar("stmt1*")
+                  , meta-listvar("stmt1*")
+                  , Stmt(Var("b"))
+                  , meta-listvar("stmt2*")
+                  ]
+                )
+              )
+            )
+          , [ WhereClause(
+                Assign(
+                  Var(ListVar("stmt2*"))
+                , App(CallNoArgs(SVar("reverse")), Var(ListVar("stmt1*")))
+                )
+              )
+            ]
+          )
+        )
+      , DefHasTypeNoArgs("surround-stmts-concrete-syntax-list-fromterm", FunNoArgsType(SortNoArgs("Start"), SortNoArgs("Start")))
+      , RDefNoArgs(
+          "surround-stmts-concrete-syntax-list-fromterm"
+        , Rule(
+            NoAnnoList(ToTerm(Program([FromTerm(Var(ListVar("stmt1*")))])))
+          , NoAnnoList(
+              ToTerm(
+                Program(
+                  [ Stmt(Var("a"))
+                  , FromTerm(Var(ListVar("stmt1*")))
+                  , Stmt(Var("b"))
+                  ]
+                )
+              )
+            )
+          , [ WhereClause(
+                Assign(
+                  Var(ListVar("stmt2*"))
+                , App(CallNoArgs(SVar("reverse")), Var(ListVar("stmt1*")))
+                )
+              )
+            ]
+          )
+        )
+      ]
+    )
+  ]
+)

--- a/sdf3.stratego2.integrationtest/trans/swap.aterm
+++ b/sdf3.stratego2.integrationtest/trans/swap.aterm
@@ -1,6 +1,21 @@
 Module(
   "swap"
 , [ Imports([Import("strategolib"), ImportWildcard("signatures")])
+  , Signature(
+      [ Constructors(
+          [ OpDecl(
+              "Conc"
+            , OpFunType(
+                [ ConstType(Sort("List", [SortVar("a")]))
+                , ConstType(Sort("List", [SortVar("a")]))
+                ]
+              , ConstType(Sort("List", [SortVar("a")]))
+              )
+            )
+          ]
+        )
+      ]
+    )
   , Rules(
       [ DefHasTypeNoArgs(
           "swap-editor-abstract-syntax"
@@ -16,7 +31,7 @@ Module(
           "swap-editor-abstract-syntax"
         , CallT(
             SVar("editor-action")
-          , [Seq(TypeTest(SortNoArgs("Exp")), CallNoArgs(SVar("swap-exps-abstract-syntax")))]
+          , [Seq(TypeTest(SortTNoArgs("Exp")), CallNoArgs(SVar("swap-exps-abstract-syntax")))]
           , []
           )
         )
@@ -34,7 +49,7 @@ Module(
           "swap-editor-concrete-syntax"
         , CallT(
             SVar("editor-action")
-          , [Seq(TypeTest(SortNoArgs("Stmt")), CallNoArgs(SVar("swap-exps-concrete-syntax")))]
+          , [Seq(TypeTest(SortTNoArgs("Stmt")), CallNoArgs(SVar("swap-exps-concrete-syntax")))]
           , []
           )
         )
@@ -52,7 +67,7 @@ Module(
           "swap-editor-concrete-syntax-simple"
         , CallT(
             SVar("editor-action")
-          , [Seq(TypeTest(SortNoArgs("Stmt")), CallNoArgs(SVar("swap-exps-concrete-syntax-simple")))]
+          , [Seq(TypeTest(SortTNoArgs("Stmt")), CallNoArgs(SVar("swap-exps-concrete-syntax-simple")))]
           , []
           )
         )
@@ -70,7 +85,7 @@ Module(
           "swap-editor-concrete-syntax-var"
         , CallT(
             SVar("editor-action")
-          , [Seq(TypeTest(SortNoArgs("Stmt")), CallNoArgs(SVar("swap-exps-concrete-syntax-var")))]
+          , [Seq(TypeTest(SortTNoArgs("Stmt")), CallNoArgs(SVar("swap-exps-concrete-syntax-var")))]
           , []
           )
         )
@@ -88,7 +103,7 @@ Module(
           "reverse-editor-concrete-syntax-varlist"
         , CallT(
             SVar("editor-action")
-          , [Seq(TypeTest(SortNoArgs("Start")), CallNoArgs(SVar("reverse-stmts-concrete-syntax-varlist")))]
+          , [Seq(TypeTest(SortTNoArgs("Start")), CallNoArgs(SVar("reverse-stmts-concrete-syntax-varlist")))]
           , []
           )
         )
@@ -106,7 +121,7 @@ Module(
           "surround-editor-concrete-syntax-varlist"
         , CallT(
             SVar("editor-action")
-          , [Seq(TypeTest(SortNoArgs("Start")), CallNoArgs(SVar("surround-stmts-concrete-syntax-varlist")))]
+          , [Seq(TypeTest(SortTNoArgs("Start")), CallNoArgs(SVar("surround-stmts-concrete-syntax-varlist")))]
           , []
           )
         )
@@ -116,10 +131,10 @@ Module(
         , []
         , FunNoArgsType(
             TupleT(
-              SortVar("a")
-            , [SortVar("b"), DynT(Dyn()), SortVar("d"), SortVar("e")]
+              SortTVar("a")
+            , [SortTVar("b"), DynT(Dyn()), SortTVar("d"), SortTVar("e")]
             )
-          , TupleT(SortVar("d"), [DynT(Dyn())])
+          , TupleT(SortTVar("d"), [DynT(Dyn())])
           )
         )
       , RDefT(
@@ -145,7 +160,7 @@ Module(
           , []
           )
         )
-      , DefHasTypeNoArgs("swap-exps-abstract-syntax", FunNoArgsType(SortNoArgs("Exp"), SortNoArgs("Exp")))
+      , DefHasTypeNoArgs("swap-exps-abstract-syntax", FunNoArgsType(SortTNoArgs("Exp"), SortTNoArgs("Exp")))
       , RDefNoArgs(
           "swap-exps-abstract-syntax"
         , Rule(
@@ -154,7 +169,7 @@ Module(
           , []
           )
         )
-      , DefHasTypeNoArgs("swap-exps-concrete-syntax", FunNoArgsType(SortNoArgs("Stmt"), SortNoArgs("Stmt")))
+      , DefHasTypeNoArgs("swap-exps-concrete-syntax", FunNoArgsType(SortTNoArgs("Stmt"), SortTNoArgs("Stmt")))
       , RDefNoArgs(
           "swap-exps-concrete-syntax"
         , Rule(
@@ -171,7 +186,7 @@ Module(
           , []
           )
         )
-      , DefHasTypeNoArgs("swap-exps-concrete-syntax-simple", FunNoArgsType(SortNoArgs("Stmt"), SortNoArgs("Stmt")))
+      , DefHasTypeNoArgs("swap-exps-concrete-syntax-simple", FunNoArgsType(SortTNoArgs("Stmt"), SortTNoArgs("Stmt")))
       , RDefNoArgs(
           "swap-exps-concrete-syntax-simple"
         , Rule(
@@ -188,7 +203,7 @@ Module(
           , []
           )
         )
-      , DefHasTypeNoArgs("swap-exps-concrete-syntax-var", FunNoArgsType(SortNoArgs("Stmt"), SortNoArgs("Stmt")))
+      , DefHasTypeNoArgs("swap-exps-concrete-syntax-var", FunNoArgsType(SortTNoArgs("Stmt"), SortTNoArgs("Stmt")))
       , RDefNoArgs(
           "swap-exps-concrete-syntax-var"
         , Rule(
@@ -197,7 +212,28 @@ Module(
           , []
           )
         )
-      , DefHasTypeNoArgs("reverse-stmts-concrete-syntax-varlist", FunNoArgsType(SortNoArgs("Start"), SortNoArgs("Start")))
+      , DefHasTypeNoArgs("reverse-stmts-abstract-syntax", FunNoArgsType(SortTNoArgs("Start"), SortTNoArgs("Start")))
+      , RDefNoArgs(
+          "reverse-stmts-abstract-syntax"
+        , Rule(
+            NoAnnoList(Op("Program", [Var(ListVar("stmt1*"))]))
+          , NoAnnoList(Op("Program", [Var(ListVar("stmt2*"))]))
+          , [ WhereClause(
+                Assign(
+                  Var(ListVar("stmt2*"))
+                , App(
+                    Seq(
+                      TypeTest(SortT("List", [SortTNoArgs("Stmt")]))
+                    , CallNoArgs(SVar("reverse"))
+                    )
+                  , Var(ListVar("stmt1*"))
+                  )
+                )
+              )
+            ]
+          )
+        )
+      , DefHasTypeNoArgs("reverse-stmts-concrete-syntax-varlist", FunNoArgsType(SortTNoArgs("Start"), SortTNoArgs("Start")))
       , RDefNoArgs(
           "reverse-stmts-concrete-syntax-varlist"
         , Rule(
@@ -206,13 +242,51 @@ Module(
           , [ WhereClause(
                 Assign(
                   Var(ListVar("stmt2*"))
-                , App(CallNoArgs(SVar("reverse")), Var(ListVar("stmt1*")))
+                , App(
+                    Seq(
+                      TypeTest(SortT("List", [SortTNoArgs("Stmt")]))
+                    , CallNoArgs(SVar("reverse"))
+                    )
+                  , Var(ListVar("stmt1*"))
+                  )
                 )
               )
             ]
           )
         )
-      , DefHasTypeNoArgs("surround-stmts-concrete-syntax-varlist", FunNoArgsType(SortNoArgs("Start"), SortNoArgs("Start")))
+      , DefHasTypeNoArgs("surround-stmts-abstract-syntax", FunNoArgsType(SortTNoArgs("Start"), SortTNoArgs("Start")))
+      , RDefNoArgs(
+          "surround-stmts-abstract-syntax"
+        , Rule(
+            NoAnnoList(Op("Program", [Var(ListVar("stmt1*"))]))
+          , NoAnnoList(
+              Op(
+                "Program"
+              , [ NoAnnoList(
+                    List(
+                      [ NoAnnoList(
+                          Op(
+                            "Stmt"
+                          , [NoAnnoList(Op("Var", [NoAnnoList(Str("\"a\""))]))]
+                          )
+                        )
+                      , Var(ListVar("stmt1*"))
+                      , NoAnnoList(
+                          Op(
+                            "Stmt"
+                          , [NoAnnoList(Op("Var", [NoAnnoList(Str("\"b\""))]))]
+                          )
+                        )
+                      ]
+                    )
+                  )
+                ]
+              )
+            )
+          , []
+          )
+        )
+      , DefHasTypeNoArgs("surround-stmts-concrete-syntax-varlist", FunNoArgsType(SortTNoArgs("Start"), SortTNoArgs("Start")))
       , RDefNoArgs(
           "surround-stmts-concrete-syntax-varlist"
         , Rule(
@@ -220,14 +294,61 @@ Module(
           , NoAnnoList(
               ToTerm(
                 Program(
-                  [Stmt(Var("a")), meta-listvar("stmt1*"), Stmt(Var("b"))]
+                  [Conc(Stmt(Var("a")), meta-listvar("stmt1*")), Stmt(Var("b"))]
                 )
               )
             )
           , []
           )
         )
-      , DefHasTypeNoArgs("surround-stmts-concrete-syntax-varlist2", FunNoArgsType(SortNoArgs("Start"), SortNoArgs("Start")))
+      , DefHasTypeNoArgs("surround-stmts-abstract-syntax2", FunNoArgsType(SortTNoArgs("Start"), SortTNoArgs("Start")))
+      , RDefNoArgs(
+          "surround-stmts-abstract-syntax2"
+        , Rule(
+            NoAnnoList(Op("Program", [Var(ListVar("stmt1*"))]))
+          , NoAnnoList(
+              Op(
+                "Program"
+              , [ NoAnnoList(
+                    List(
+                      [ Var(ListVar("stmt2*"))
+                      , NoAnnoList(
+                          Op(
+                            "Stmt"
+                          , [NoAnnoList(Op("Var", [NoAnnoList(Str("\"a\""))]))]
+                          )
+                        )
+                      , Var(ListVar("stmt1*"))
+                      , Var(ListVar("stmt1*"))
+                      , NoAnnoList(
+                          Op(
+                            "Stmt"
+                          , [NoAnnoList(Op("Var", [NoAnnoList(Str("\"b\""))]))]
+                          )
+                        )
+                      , Var(ListVar("stmt2*"))
+                      ]
+                    )
+                  )
+                ]
+              )
+            )
+          , [ WhereClause(
+                Assign(
+                  Var(ListVar("stmt2*"))
+                , App(
+                    Seq(
+                      TypeTest(SortT("List", [SortTNoArgs("Stmt")]))
+                    , CallNoArgs(SVar("reverse"))
+                    )
+                  , Var(ListVar("stmt1*"))
+                  )
+                )
+              )
+            ]
+          )
+        )
+      , DefHasTypeNoArgs("surround-stmts-concrete-syntax-varlist2", FunNoArgsType(SortTNoArgs("Start"), SortTNoArgs("Start")))
       , RDefNoArgs(
           "surround-stmts-concrete-syntax-varlist2"
         , Rule(
@@ -235,26 +356,33 @@ Module(
           , NoAnnoList(
               ToTerm(
                 Program(
-                  [ meta-listvar("stmt2*")
-                  , Stmt(Var("a"))
-                  , meta-listvar("stmt1*")
-                  , meta-listvar("stmt1*")
+                  Conc(
+                    Conc(
+                      Conc(meta-listvar("stmt2*"), Stmt(Var("a")), meta-listvar("stmt1*"))
+                    , meta-listvar("stmt1*")
+                    )
                   , Stmt(Var("b"))
                   , meta-listvar("stmt2*")
-                  ]
+                  )
                 )
               )
             )
           , [ WhereClause(
                 Assign(
                   Var(ListVar("stmt2*"))
-                , App(CallNoArgs(SVar("reverse")), Var(ListVar("stmt1*")))
+                , App(
+                    Seq(
+                      TypeTest(SortT("List", [SortTNoArgs("Stmt")]))
+                    , CallNoArgs(SVar("reverse"))
+                    )
+                  , Var(ListVar("stmt1*"))
+                  )
                 )
               )
             ]
           )
         )
-      , DefHasTypeNoArgs("surround-stmts-concrete-syntax-list-fromterm", FunNoArgsType(SortNoArgs("Start"), SortNoArgs("Start")))
+      , DefHasTypeNoArgs("surround-stmts-concrete-syntax-list-fromterm", FunNoArgsType(SortTNoArgs("Start"), SortTNoArgs("Start")))
       , RDefNoArgs(
           "surround-stmts-concrete-syntax-list-fromterm"
         , Rule(
@@ -262,8 +390,7 @@ Module(
           , NoAnnoList(
               ToTerm(
                 Program(
-                  [ Stmt(Var("a"))
-                  , FromTerm(Var(ListVar("stmt1*")))
+                  [ Conc(Stmt(Var("a")), FromTerm(Var(ListVar("stmt1*"))))
                   , Stmt(Var("b"))
                   ]
                 )
@@ -272,7 +399,13 @@ Module(
           , [ WhereClause(
                 Assign(
                   Var(ListVar("stmt2*"))
-                , App(CallNoArgs(SVar("reverse")), Var(ListVar("stmt1*")))
+                , App(
+                    Seq(
+                      TypeTest(SortT("List", [SortTNoArgs("Stmt")]))
+                    , CallNoArgs(SVar("reverse"))
+                    )
+                  , Var(ListVar("stmt1*"))
+                  )
                 )
               )
             ]

--- a/sdf3.stratego2.integrationtest/trans/swap.meta
+++ b/sdf3.stratego2.integrationtest/trans/swap.meta
@@ -1,0 +1,1 @@
+Meta([Syntax("foo")])

--- a/sdf3.stratego2.integrationtest/trans/swap.str2
+++ b/sdf3.stratego2.integrationtest/trans/swap.str2
@@ -40,33 +40,33 @@ rules
 
   swap-exps-concrete-syntax-simple :: Stmt -> Stmt
   swap-exps-concrete-syntax-simple:
-    |[ ~e1 + ~e2; ]| ->
-    |[ ~e2 + ~e1; ]|
+    stmt |[ ~e1 + ~e2; ]| ->
+    stmt |[ ~e2 + ~e1; ]|
 
   swap-exps-concrete-syntax-var :: Stmt -> Stmt
   swap-exps-concrete-syntax-var:
-    |[ exp + exp2 ; ]| ->
-    |[ exp2 + exp ; ]|
+    stmt |[ exp + exp2 ; ]| ->
+    stmt |[ exp2 + exp ; ]|
 
   reverse-stmts-concrete-syntax-varlist :: Start -> Start
   reverse-stmts-concrete-syntax-varlist:
-    |[ stmt1* ]| ->
-    |[ stmt2* ]|
+    program |[ stmt1* ]| ->
+    program |[ stmt2* ]|
   where stmt2* := <reverse> stmt1*
 
   surround-stmts-concrete-syntax-varlist :: Start -> Start
   surround-stmts-concrete-syntax-varlist:
-    |[ stmt1* ]|  ->
+    program |[ stmt1* ]|  ->
     program |[ a; stmt1* b; ]|
 
   surround-stmts-concrete-syntax-varlist2 :: Start -> Start
   surround-stmts-concrete-syntax-varlist2:
-    |[ stmt1* ]|  ->
+    program |[ stmt1* ]|  ->
     program |[ stmt2* a; stmt1* stmt1* b; stmt2* ]|
   where stmt2* := <reverse> stmt1*
 
   surround-stmts-concrete-syntax-list-fromterm :: Start -> Start
   surround-stmts-concrete-syntax-list-fromterm:
-    |[ ~*stmt1* ]|  ->
+    program |[ ~*stmt1* ]|  ->
     program |[ a; ~*stmt1* b; ]|
   where stmt2* := <reverse> stmt1*

--- a/sdf3.stratego2.integrationtest/trans/swap.str2
+++ b/sdf3.stratego2.integrationtest/trans/swap.str2
@@ -7,23 +7,29 @@ imports
 
 rules
 
-  swap-editor-abstract-syntax :: ? * ? * ? * ? * ? -> ? * ?
-  swap-editor-abstract-syntax        = editor-action(is(Exp);swap-exps-abstract-syntax|)
+  editor-action-swap-exps-abstract-syntax :: ? * ? * ? * ? * ? -> ? * ?
+  editor-action-swap-exps-abstract-syntax        = editor-action(is(Exp);swap-exps-abstract-syntax|)
 
-  swap-editor-concrete-syntax :: ? * ? * ? * ? * ? -> ? * ?
-  swap-editor-concrete-syntax        = editor-action(is(Stmt);swap-exps-concrete-syntax|)
+  editor-action-swap-exps-concrete-syntax :: ? * ? * ? * ? * ? -> ? * ?
+  editor-action-swap-exps-concrete-syntax        = editor-action(is(Stmt);swap-exps-concrete-syntax|)
 
-  swap-editor-concrete-syntax-simple :: ? * ? * ? * ? * ? -> ? * ?
-  swap-editor-concrete-syntax-simple = editor-action(is(Stmt);swap-exps-concrete-syntax-simple|)
+  editor-action-swap-exps-concrete-syntax-simple :: ? * ? * ? * ? * ? -> ? * ?
+  editor-action-swap-exps-concrete-syntax-simple = editor-action(is(Stmt);swap-exps-concrete-syntax-simple|)
 
-  swap-editor-concrete-syntax-var :: ? * ? * ? * ? * ? -> ? * ?
-  swap-editor-concrete-syntax-var = editor-action(is(Stmt);swap-exps-concrete-syntax-var|)
+  editor-action-swap-exps-concrete-syntax-var :: ? * ? * ? * ? * ? -> ? * ?
+  editor-action-swap-exps-concrete-syntax-var = editor-action(is(Stmt);swap-exps-concrete-syntax-var|)
 
-  reverse-editor-concrete-syntax-varlist :: ? * ? * ? * ? * ? -> ? * ?
-  reverse-editor-concrete-syntax-varlist = editor-action(is(Start);reverse-stmts-concrete-syntax-varlist|)
+  editor-action-reverse-stmts-concrete-syntax-varlist :: ? * ? * ? * ? * ? -> ? * ?
+  editor-action-reverse-stmts-concrete-syntax-varlist = editor-action(is(Start);reverse-stmts-concrete-syntax-varlist|)
 
-  surround-editor-concrete-syntax-varlist :: ? * ? * ? * ? * ? -> ? * ?
-  surround-editor-concrete-syntax-varlist = editor-action(is(Start);surround-stmts-concrete-syntax-varlist|)
+  editor-action-surround-stmts-concrete-syntax-varlist :: ? * ? * ? * ? * ? -> ? * ?
+  editor-action-surround-stmts-concrete-syntax-varlist = editor-action(is(Start);surround-stmts-concrete-syntax-varlist|)
+
+  editor-action-surround-stmts-concrete-syntax-varlist2 :: ? * ? * ? * ? * ? -> ? * ?
+  editor-action-surround-stmts-concrete-syntax-varlist2 = editor-action(is(Start);surround-stmts-concrete-syntax-varlist2|)
+
+  editor-action-surround-stmts-concrete-syntax-list-fromterm :: ? * ? * ? * ? * ? -> ? * ?
+  editor-action-surround-stmts-concrete-syntax-list-fromterm = editor-action(is(Start);surround-stmts-concrete-syntax-list-fromterm|)
 
   editor-action(? -> ?|) :: a * b * ? * d * e -> d * ?
   editor-action(swap-exp|):
@@ -67,6 +73,5 @@ rules
 
   surround-stmts-concrete-syntax-list-fromterm :: Start -> Start
   surround-stmts-concrete-syntax-list-fromterm:
-    program |[ ~*stmt1* ]|  ->
-    program |[ a; ~*stmt1* b; ]|
-  where stmt2* := <reverse> stmt1*
+    program |[ ~stmt1* ]|  ->
+    program |[ a; ~stmt1* b; ]|

--- a/sdf3.stratego2.integrationtest/trans/swap.str2
+++ b/sdf3.stratego2.integrationtest/trans/swap.str2
@@ -1,0 +1,72 @@
+module swap
+
+imports
+
+  strategolib
+  signatures/-
+
+rules
+
+  swap-editor-abstract-syntax :: ? * ? * ? * ? * ? -> ? * ?
+  swap-editor-abstract-syntax        = editor-action(is(Exp);swap-exps-abstract-syntax|)
+
+  swap-editor-concrete-syntax :: ? * ? * ? * ? * ? -> ? * ?
+  swap-editor-concrete-syntax        = editor-action(is(Stmt);swap-exps-concrete-syntax|)
+
+  swap-editor-concrete-syntax-simple :: ? * ? * ? * ? * ? -> ? * ?
+  swap-editor-concrete-syntax-simple = editor-action(is(Stmt);swap-exps-concrete-syntax-simple|)
+
+  swap-editor-concrete-syntax-var :: ? * ? * ? * ? * ? -> ? * ?
+  swap-editor-concrete-syntax-var = editor-action(is(Stmt);swap-exps-concrete-syntax-var|)
+
+  reverse-editor-concrete-syntax-varlist :: ? * ? * ? * ? * ? -> ? * ?
+  reverse-editor-concrete-syntax-varlist = editor-action(is(Start);reverse-stmts-concrete-syntax-varlist|)
+
+  surround-editor-concrete-syntax-varlist :: ? * ? * ? * ? * ? -> ? * ?
+  surround-editor-concrete-syntax-varlist = editor-action(is(Start);surround-stmts-concrete-syntax-varlist|)
+
+  editor-action(? -> ?|) :: a * b * ? * d * e -> d * ?
+  editor-action(swap-exp|):
+    (_, _, ast, path, _) -> (path, <oncetd(swap-exp)> ast) 
+
+  swap-exps-abstract-syntax :: Exp -> Exp
+  swap-exps-abstract-syntax:
+    Add(e1, e2) -> Add(e2, e1)
+
+  swap-exps-concrete-syntax :: Stmt -> Stmt
+  swap-exps-concrete-syntax:
+    stmt |[ ~exp:e1 + ~exp:e2; ]| ->
+    stmt |[ ~exp:e2 + ~exp:e1; ]|
+
+  swap-exps-concrete-syntax-simple :: Stmt -> Stmt
+  swap-exps-concrete-syntax-simple:
+    |[ ~e1 + ~e2; ]| ->
+    |[ ~e2 + ~e1; ]|
+
+  swap-exps-concrete-syntax-var :: Stmt -> Stmt
+  swap-exps-concrete-syntax-var:
+    |[ exp + exp2 ; ]| ->
+    |[ exp2 + exp ; ]|
+
+  reverse-stmts-concrete-syntax-varlist :: Start -> Start
+  reverse-stmts-concrete-syntax-varlist:
+    |[ stmt1* ]| ->
+    |[ stmt2* ]|
+  where stmt2* := <reverse> stmt1*
+
+  surround-stmts-concrete-syntax-varlist :: Start -> Start
+  surround-stmts-concrete-syntax-varlist:
+    |[ stmt1* ]|  ->
+    program |[ a; stmt1* b; ]|
+
+  surround-stmts-concrete-syntax-varlist2 :: Start -> Start
+  surround-stmts-concrete-syntax-varlist2:
+    |[ stmt1* ]|  ->
+    program |[ stmt2* a; stmt1* stmt1* b; stmt2* ]|
+  where stmt2* := <reverse> stmt1*
+
+  surround-stmts-concrete-syntax-list-fromterm :: Start -> Start
+  surround-stmts-concrete-syntax-list-fromterm:
+    |[ ~*stmt1* ]|  ->
+    program |[ a; ~*stmt1* b; ]|
+  where stmt2* := <reverse> stmt1*


### PR DESCRIPTION
This adds explicit SDF3 rules that introduce some meta-variables. These used to be introduced in a `variables` section in SDF2, which was a little magical. SDF3 normaliser seems to throw away a `variables` section in SDF3 files. The limitation of explicit context-free rules is that this doesn't work for meta-list-variables. So perhaps we should fix the support for the `variables` section, or for explicit list variable rules. You can write them, like:
```
Stmt+.meta-list-var = StmtListVar
```
But the parse result isn't quite right. 