### PR TITLE
Remove ECJ dependency

### DIFF
--- a/org.metaborg.meta.lang.template/build.gradle.kts
+++ b/org.metaborg.meta.lang.template/build.gradle.kts
@@ -25,6 +25,12 @@ dependencies {
   sourceLanguage(compositeBuild("statix.runtime"))
 }
 
+metaborg { // Do not create Java publication; this project is already published as a Spoofax 2 language.
+  javaCreatePublication = false
+  javaCreateSourcesJar = false
+  javaCreateJavadocJar = false
+}
+
 ecj {
   toolVersion = "3.21.0"
 }

--- a/org.metaborg.meta.lang.template/build.gradle.kts
+++ b/org.metaborg.meta.lang.template/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
   id("org.metaborg.gradle.config.java-library")
   id("org.metaborg.devenv.spoofax.gradle.langspec")
-  id("de.set.ecj") // Use ECJ to speed up compilation of Stratego's generated Java files.
   `maven-publish`
 }
 
@@ -29,11 +28,4 @@ metaborg { // Do not create Java publication; this project is already published 
   javaCreatePublication = false
   javaCreateSourcesJar = false
   javaCreateJavadocJar = false
-}
-
-ecj {
-  toolVersion = "3.21.0"
-}
-tasks.withType<JavaCompile> { // ECJ does not support headerOutputDirectory (-h argument).
-  options.headerOutputDirectory.convention(provider { null })
 }

--- a/org.metaborg.meta.lang.template/editor/Main.esv
+++ b/org.metaborg.meta.lang.template/editor/Main.esv
@@ -17,8 +17,11 @@ language
   provider : target/metaborg/stratego.ctree
   provider : target/metaborg/stratego.jar
   observer : editor-analyze (multifile)
+  //observer: statix-editor-analyze (constraint) (multifile)
   on save  : editor-save
 
 references
 
   reference _ : editor-resolve
+  //reference _ : stx-editor-resolve
+  //hover _ : stx-editor-hover

--- a/org.metaborg.meta.lang.template/trans/generation/pp/to-pp.str
+++ b/org.metaborg.meta.lang.template/trans/generation/pp/to-pp.str
@@ -53,6 +53,7 @@ rules
                 Import("libspoofax/sdf/pp"),
                 Import("libspoofax/term/origin"),
                 Import("libspoofax/term/annotation"),
+                Import("libspoofax/editor/refactoring/construct-text"),
 
                 Import(<to-str-module-name(|"-sig","signatures")> Module(m))
               ])

--- a/org.metaborg.meta.lang.template/trans/statix/attribute.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/attribute.stx
@@ -18,7 +18,7 @@ signature
     LayoutConstraint : Constraint -> Attribute
     
   sorts ConstraintTreeRef constructors
-    PosRef     : string -> ConstraintTreeRef
+    PosRef     : int -> ConstraintTreeRef
     LiteralRef : string -> ConstraintTreeRef
     LabelRef   : string -> ConstraintTreeRef
     
@@ -78,8 +78,10 @@ rules
 rules
 
   constraintTreeRefOk : scope * int * ConstraintTreeRef
-  constraintTreeRefOk(s, numNonTerminals, PosRef(index)).
-    // TODO: check index
+  constraintTreeRefOk(s, numNonTerminals, PosRef(index)). //:-
+    // disabled: cannot check indices as parser does some tokenization on template syntax that is not apparent from the
+    // surface syntax.
+    //try { index #< numNonTerminals } | error $[Index [index] (0-based) exeeds the number of non-layout elements [numNonTerminals]. Change the index to be < [numNonTerminals]].
   constraintTreeRefOk(s, numNonTerminals, LiteralRef(literal)).
     // TODO: check literal
   constraintTreeRefOk(s, numNonTerminals, LabelRef(label)) :-
@@ -140,7 +142,7 @@ rules
   constraintOk(s, numNonTerminals, Or(c1, c2)) :- 
     constraintOk(s, numNonTerminals, c1),
     constraintOk(s, numNonTerminals, c2).
-  
+
   constraintOk(s, numNonTerminals, Offside(ref, refs)) :- 
     constraintTreeRefOk(s, numNonTerminals, ref),
     constraintTreeRefsOk(s, numNonTerminals, refs).
@@ -181,7 +183,7 @@ rules
   constraintOk(s, numNonTerminals, PPNewLineBy(Digits(index), ref)) :- 
     constraintTreeRefOk(s, numNonTerminals, ref).
     // TODO: check index
-          
+
 rules
 
   hasAttribute: Attribute * Attributes -> BOOL
@@ -195,3 +197,4 @@ rules
   hasAttributeInList(attr, [attr|_]) = TRUE().
   hasAttributeInList(attr, [_   |s]) = hasAttributeInList(attr, s).
   hasAttributeInList(attr, [      ]) = FALSE().
+

--- a/org.metaborg.meta.lang.template/trans/statix/attribute.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/attribute.stx
@@ -65,123 +65,123 @@ signature
 
 rules
 
-  attributesOk : scope * int * Attributes
-  attributesOk(s, numNonTerminals, attrs) :-
-    singleAttributesOk(s, numNonTerminals, attributes(attrs)).
+  attributesOk : scope * Attributes
+  attributesOk(s, attrs) :-
+    singleAttributesOk(s, attributes(attrs)).
 
-  attributeOk : scope * int * Attribute
-  attributeOk(s, numNonTerminals, LayoutConstraint(constraint)) :-
-    constraintOk(s, numNonTerminals, constraint).
-  attributeOk(_, _, _).
-  singleAttributesOk maps attributeOk(*, *, list(*))
+  attributeOk : scope * Attribute
+  attributeOk(s, LayoutConstraint(constraint)) :-
+    constraintOk(s, constraint).
+  attributeOk(_, _).
+  singleAttributesOk maps attributeOk(*, list(*))
   
 rules
 
-  constraintTreeRefOk : scope * int * ConstraintTreeRef
-  constraintTreeRefOk(s, numNonTerminals, PosRef(index)). //:-
+  constraintTreeRefOk : scope * ConstraintTreeRef
+  constraintTreeRefOk(s, PosRef(index)). //:-
     // disabled: cannot check indices as parser does some tokenization on template syntax that is not apparent from the
     // surface syntax.
     //try { index #< numNonTerminals } | error $[Index [index] (0-based) exeeds the number of non-layout elements [numNonTerminals]. Change the index to be < [numNonTerminals]].
-  constraintTreeRefOk(s, numNonTerminals, LiteralRef(literal)).
+  constraintTreeRefOk(s, LiteralRef(literal)).
     // TODO: check literal
-  constraintTreeRefOk(s, numNonTerminals, LabelRef(label)) :-
+  constraintTreeRefOk(s, LabelRef(label)) :-
     resolveLabel(s, label). 
-  constraintTreeRefsOk maps constraintTreeRefOk(*, *, list(*))
+  constraintTreeRefsOk maps constraintTreeRefOk(*, list(*))
 
-  constraintTokenOk : scope * int * ConstraintToken
-  constraintTokenOk(s, numNonTerminals, First(ref)) :-
-    constraintTreeRefOk(s, numNonTerminals, ref).
-  constraintTokenOk(s, numNonTerminals, Left(ref)) :-
-    constraintTreeRefOk(s, numNonTerminals, ref).
-  constraintTokenOk(s, numNonTerminals, Right(ref)) :-
-    constraintTreeRefOk(s, numNonTerminals, ref).
-  constraintTokenOk(s, numNonTerminals, Last(ref)) :-
-    constraintTreeRefOk(s, numNonTerminals, ref).
+  constraintTokenOk : scope * ConstraintToken
+  constraintTokenOk(s, First(ref)) :-
+    constraintTreeRefOk(s, ref).
+  constraintTokenOk(s, Left(ref)) :-
+    constraintTreeRefOk(s, ref).
+  constraintTokenOk(s, Right(ref)) :-
+    constraintTreeRefOk(s, ref).
+  constraintTokenOk(s, Last(ref)) :-
+    constraintTreeRefOk(s, ref).
     
-  constraintExpOk : scope * int * ConstraintExp
-  constraintExpOk(s, numNonTerminals, Mul(exp1, exp2)) :-
-    constraintExpOk(s, numNonTerminals, exp1),
-    constraintExpOk(s, numNonTerminals, exp2).
-  constraintExpOk(s, numNonTerminals, Div(exp1, exp2)) :-
-    constraintExpOk(s, numNonTerminals, exp1),
-    constraintExpOk(s, numNonTerminals, exp2).
-  constraintExpOk(s, numNonTerminals, Add(exp1, exp2)) :-
-    constraintExpOk(s, numNonTerminals, exp1),
-    constraintExpOk(s, numNonTerminals, exp2).
-  constraintExpOk(s, numNonTerminals, Sub(exp1, exp2)) :-
-    constraintExpOk(s, numNonTerminals, exp1),
-    constraintExpOk(s, numNonTerminals, exp2).
-  constraintExpOk(s, numNonTerminals, ConstraintExpLine(token)) :-
-    constraintTokenOk(s, numNonTerminals, token).
-  constraintExpOk(s, numNonTerminals, Col(token)) :-
-    constraintTokenOk(s, numNonTerminals, token).
-  constraintExpOk(s, numNonTerminals, Num(Digits(index))).
+  constraintExpOk : scope * ConstraintExp
+  constraintExpOk(s, Mul(exp1, exp2)) :-
+    constraintExpOk(s, exp1),
+    constraintExpOk(s, exp2).
+  constraintExpOk(s, Div(exp1, exp2)) :-
+    constraintExpOk(s, exp1),
+    constraintExpOk(s, exp2).
+  constraintExpOk(s, Add(exp1, exp2)) :-
+    constraintExpOk(s, exp1),
+    constraintExpOk(s, exp2).
+  constraintExpOk(s, Sub(exp1, exp2)) :-
+    constraintExpOk(s, exp1),
+    constraintExpOk(s, exp2).
+  constraintExpOk(s, ConstraintExpLine(token)) :-
+    constraintTokenOk(s, token).
+  constraintExpOk(s, Col(token)) :-
+    constraintTokenOk(s, token).
+  constraintExpOk(s, Num(Digits(index))).
     // TODO: check index
         
-  constraintOk : scope * int * Constraint
-  constraintOk(s, numNonTerminals, Eq(exp1, exp2)) :- 
-    constraintExpOk(s, numNonTerminals, exp1),
-    constraintExpOk(s, numNonTerminals, exp2).
-  constraintOk(s, numNonTerminals, Lt(exp1, exp2)) :- 
-    constraintExpOk(s, numNonTerminals, exp1),
-    constraintExpOk(s, numNonTerminals, exp2).
-  constraintOk(s, numNonTerminals, Le(exp1, exp2)) :- 
-    constraintExpOk(s, numNonTerminals, exp1),
-    constraintExpOk(s, numNonTerminals, exp2).
-  constraintOk(s, numNonTerminals, Gt(exp1, exp2)) :- 
-    constraintExpOk(s, numNonTerminals, exp1),
-    constraintExpOk(s, numNonTerminals, exp2).
-  constraintOk(s, numNonTerminals, Ge(exp1, exp2)) :- 
-    constraintExpOk(s, numNonTerminals, exp1),
-    constraintExpOk(s, numNonTerminals, exp2).
-  constraintOk(s, numNonTerminals, Not(c)) :- 
-    constraintOk(s, numNonTerminals, c).
-  constraintOk(s, numNonTerminals, And(c1, c2)) :- 
-    constraintOk(s, numNonTerminals, c1),
-    constraintOk(s, numNonTerminals, c2).
-  constraintOk(s, numNonTerminals, Or(c1, c2)) :- 
-    constraintOk(s, numNonTerminals, c1),
-    constraintOk(s, numNonTerminals, c2).
+  constraintOk : scope * Constraint
+  constraintOk(s, Eq(exp1, exp2)) :- 
+    constraintExpOk(s, exp1),
+    constraintExpOk(s, exp2).
+  constraintOk(s, Lt(exp1, exp2)) :- 
+    constraintExpOk(s, exp1),
+    constraintExpOk(s, exp2).
+  constraintOk(s, Le(exp1, exp2)) :- 
+    constraintExpOk(s, exp1),
+    constraintExpOk(s, exp2).
+  constraintOk(s, Gt(exp1, exp2)) :- 
+    constraintExpOk(s, exp1),
+    constraintExpOk(s, exp2).
+  constraintOk(s, Ge(exp1, exp2)) :- 
+    constraintExpOk(s, exp1),
+    constraintExpOk(s, exp2).
+  constraintOk(s, Not(c)) :- 
+    constraintOk(s, c).
+  constraintOk(s, And(c1, c2)) :- 
+    constraintOk(s, c1),
+    constraintOk(s, c2).
+  constraintOk(s, Or(c1, c2)) :- 
+    constraintOk(s, c1),
+    constraintOk(s, c2).
 
-  constraintOk(s, numNonTerminals, Offside(ref, refs)) :- 
-    constraintTreeRefOk(s, numNonTerminals, ref),
-    constraintTreeRefsOk(s, numNonTerminals, refs).
-  constraintOk(s, numNonTerminals, Indent(ref, refs)) :- 
-    constraintTreeRefOk(s, numNonTerminals, ref),
-    constraintTreeRefsOk(s, numNonTerminals, refs).
-  constraintOk(s, numNonTerminals, Align(ref, refs)) :- 
-    constraintTreeRefOk(s, numNonTerminals, ref),
-    constraintTreeRefsOk(s, numNonTerminals, refs).
-  constraintOk(s, numNonTerminals, AlignList(ref)) :- 
-    constraintTreeRefOk(s, numNonTerminals, ref).
-  constraintOk(s, numNonTerminals, NewLineIndent(ref, refs)) :- 
-    constraintTreeRefOk(s, numNonTerminals, ref),
-    constraintTreeRefsOk(s, numNonTerminals, refs).
-  constraintOk(s, numNonTerminals, SingleLine(refs)) :- 
-    constraintTreeRefsOk(s, numNonTerminals, refs).
+  constraintOk(s, Offside(ref, refs)) :- 
+    constraintTreeRefOk(s, ref),
+    constraintTreeRefsOk(s, refs).
+  constraintOk(s, Indent(ref, refs)) :- 
+    constraintTreeRefOk(s, ref),
+    constraintTreeRefsOk(s, refs).
+  constraintOk(s, Align(ref, refs)) :- 
+    constraintTreeRefOk(s, ref),
+    constraintTreeRefsOk(s, refs).
+  constraintOk(s, AlignList(ref)) :- 
+    constraintTreeRefOk(s, ref).
+  constraintOk(s, NewLineIndent(ref, refs)) :- 
+    constraintTreeRefOk(s, ref),
+    constraintTreeRefsOk(s, refs).
+  constraintOk(s, SingleLine(refs)) :- 
+    constraintTreeRefsOk(s, refs).
 
-  constraintOk(s, numNonTerminals, PPOffside(ref, refs)) :- 
-    constraintTreeRefOk(s, numNonTerminals, ref),
-    constraintTreeRefsOk(s, numNonTerminals, refs).
-  constraintOk(s, numNonTerminals, PPIndent(ref, refs)) :- 
-    constraintTreeRefOk(s, numNonTerminals, ref),
-    constraintTreeRefsOk(s, numNonTerminals, refs).
-  constraintOk(s, numNonTerminals, PPAlign(ref, refs)) :- 
-    constraintTreeRefOk(s, numNonTerminals, ref),
-    constraintTreeRefsOk(s, numNonTerminals, refs).
-  constraintOk(s, numNonTerminals, PPAlignList(ref)) :- 
-    constraintTreeRefOk(s, numNonTerminals, ref).
-  constraintOk(s, numNonTerminals, PPNewLineIndent(ref, refs)) :- 
-    constraintTreeRefOk(s, numNonTerminals, ref),
-    constraintTreeRefsOk(s, numNonTerminals, refs).
-  constraintOk(s, numNonTerminals, PPNewLineIndentBy(Digits(index), ref, refs)) :- 
-    constraintTreeRefOk(s, numNonTerminals, ref),
-    constraintTreeRefsOk(s, numNonTerminals, refs).
+  constraintOk(s, PPOffside(ref, refs)) :- 
+    constraintTreeRefOk(s, ref),
+    constraintTreeRefsOk(s, refs).
+  constraintOk(s, PPIndent(ref, refs)) :- 
+    constraintTreeRefOk(s, ref),
+    constraintTreeRefsOk(s, refs).
+  constraintOk(s, PPAlign(ref, refs)) :- 
+    constraintTreeRefOk(s, ref),
+    constraintTreeRefsOk(s, refs).
+  constraintOk(s, PPAlignList(ref)) :- 
+    constraintTreeRefOk(s, ref).
+  constraintOk(s, PPNewLineIndent(ref, refs)) :- 
+    constraintTreeRefOk(s, ref),
+    constraintTreeRefsOk(s, refs).
+  constraintOk(s, PPNewLineIndentBy(Digits(index), ref, refs)) :- 
+    constraintTreeRefOk(s, ref),
+    constraintTreeRefsOk(s, refs).
     // TODO: check index
-  constraintOk(s, numNonTerminals, PPNewLine(ref)) :- 
-    constraintTreeRefOk(s, numNonTerminals, ref).
-  constraintOk(s, numNonTerminals, PPNewLineBy(Digits(index), ref)) :- 
-    constraintTreeRefOk(s, numNonTerminals, ref).
+  constraintOk(s, PPNewLine(ref)) :- 
+    constraintTreeRefOk(s, ref).
+  constraintOk(s, PPNewLineBy(Digits(index), ref)) :- 
+    constraintTreeRefOk(s, ref).
     // TODO: check index
 
 rules

--- a/org.metaborg.meta.lang.template/trans/statix/attribute.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/attribute.stx
@@ -3,6 +3,8 @@ module statix/attribute
 imports
 
   statix/util
+  statix/constant
+  statix/label
 
 signature
 
@@ -11,9 +13,175 @@ signature
     NoAttrs :                    Attributes
 
   sorts Attribute constructors
-    Reject  : Attribute
-    Bracket : Attribute
+    Reject           :               Attribute
+    Bracket          :               Attribute
+    LayoutConstraint : Constraint -> Attribute
+    
+  sorts ConstraintTreeRef constructors
+    PosRef     : string -> ConstraintTreeRef
+    LiteralRef : string -> ConstraintTreeRef
+    LabelRef   : string -> ConstraintTreeRef
+    
+  sorts ConstraintToken constructors
+    First : ConstraintTreeRef -> ConstraintToken
+    Left  : ConstraintTreeRef -> ConstraintToken
+    Right : ConstraintTreeRef -> ConstraintToken
+    Last  : ConstraintTreeRef -> ConstraintToken
+    
+  sorts ConstraintExp constructors
+    Mul               : ConstraintExp * ConstraintExp -> ConstraintExp
+    Div               : ConstraintExp * ConstraintExp -> ConstraintExp
+    Add               : ConstraintExp * ConstraintExp -> ConstraintExp
+    Sub               : ConstraintExp * ConstraintExp -> ConstraintExp
+    ConstraintExpLine : ConstraintToken               -> ConstraintExp
+    Col               : ConstraintToken               -> ConstraintExp
+    Num               : NatCon                        -> ConstraintExp
+    
+  sorts Constraint constructors
+    Eq  : ConstraintExp * ConstraintExp -> Constraint
+    Lt  : ConstraintExp * ConstraintExp -> Constraint
+    Le  : ConstraintExp * ConstraintExp -> Constraint
+    Gt  : ConstraintExp * ConstraintExp -> Constraint
+    Ge  : ConstraintExp * ConstraintExp -> Constraint
+    Not : Constraint                    -> Constraint
+    And : Constraint * Constraint       -> Constraint
+    Or  : Constraint * Constraint       -> Constraint
+    
+    Offside       : ConstraintTreeRef * list(ConstraintTreeRef) -> Constraint
+    Indent        : ConstraintTreeRef * list(ConstraintTreeRef) -> Constraint
+    Align         : ConstraintTreeRef * list(ConstraintTreeRef) -> Constraint
+    AlignList     : ConstraintTreeRef                           -> Constraint
+    NewLineIndent : ConstraintTreeRef * list(ConstraintTreeRef) -> Constraint
+    SingleLine    : list(ConstraintTreeRef)                     -> Constraint
 
+    PPOffside         : ConstraintTreeRef * list(ConstraintTreeRef)          -> Constraint
+    PPIndent          : ConstraintTreeRef * list(ConstraintTreeRef)          -> Constraint
+    PPAlign           : ConstraintTreeRef * list(ConstraintTreeRef)          -> Constraint
+    PPAlignList       : ConstraintTreeRef                                    -> Constraint
+    PPNewLineIndent   : ConstraintTreeRef * list(ConstraintTreeRef)          -> Constraint
+    PPNewLineIndentBy : NatCon * ConstraintTreeRef * list(ConstraintTreeRef) -> Constraint
+    PPNewLine         : ConstraintTreeRef                                    -> Constraint
+    PPNewLineBy       : NatCon * ConstraintTreeRef                           -> Constraint
+
+rules
+
+  attributesOk : scope * int * Attributes
+  attributesOk(s, numNonTerminals, attrs) :-
+    singleAttributesOk(s, numNonTerminals, attributes(attrs)).
+
+  attributeOk : scope * int * Attribute
+  attributeOk(s, numNonTerminals, LayoutConstraint(constraint)) :-
+    constraintOk(s, numNonTerminals, constraint).
+  attributeOk(_, _, _).
+  singleAttributesOk maps attributeOk(*, *, list(*))
+  
+rules
+
+  constraintTreeRefOk : scope * int * ConstraintTreeRef
+  constraintTreeRefOk(s, numNonTerminals, PosRef(index)).
+    // TODO: check index
+  constraintTreeRefOk(s, numNonTerminals, LiteralRef(literal)).
+    // TODO: check literal
+  constraintTreeRefOk(s, numNonTerminals, LabelRef(label)) :-
+    resolveLabel(s, label). 
+  constraintTreeRefsOk maps constraintTreeRefOk(*, *, list(*))
+
+  constraintTokenOk : scope * int * ConstraintToken
+  constraintTokenOk(s, numNonTerminals, First(ref)) :-
+    constraintTreeRefOk(s, numNonTerminals, ref).
+  constraintTokenOk(s, numNonTerminals, Left(ref)) :-
+    constraintTreeRefOk(s, numNonTerminals, ref).
+  constraintTokenOk(s, numNonTerminals, Right(ref)) :-
+    constraintTreeRefOk(s, numNonTerminals, ref).
+  constraintTokenOk(s, numNonTerminals, Last(ref)) :-
+    constraintTreeRefOk(s, numNonTerminals, ref).
+    
+  constraintExpOk : scope * int * ConstraintExp
+  constraintExpOk(s, numNonTerminals, Mul(exp1, exp2)) :-
+    constraintExpOk(s, numNonTerminals, exp1),
+    constraintExpOk(s, numNonTerminals, exp2).
+  constraintExpOk(s, numNonTerminals, Div(exp1, exp2)) :-
+    constraintExpOk(s, numNonTerminals, exp1),
+    constraintExpOk(s, numNonTerminals, exp2).
+  constraintExpOk(s, numNonTerminals, Add(exp1, exp2)) :-
+    constraintExpOk(s, numNonTerminals, exp1),
+    constraintExpOk(s, numNonTerminals, exp2).
+  constraintExpOk(s, numNonTerminals, Sub(exp1, exp2)) :-
+    constraintExpOk(s, numNonTerminals, exp1),
+    constraintExpOk(s, numNonTerminals, exp2).
+  constraintExpOk(s, numNonTerminals, ConstraintExpLine(token)) :-
+    constraintTokenOk(s, numNonTerminals, token).
+  constraintExpOk(s, numNonTerminals, Col(token)) :-
+    constraintTokenOk(s, numNonTerminals, token).
+  constraintExpOk(s, numNonTerminals, Num(Digits(index))).
+    // TODO: check index
+        
+  constraintOk : scope * int * Constraint
+  constraintOk(s, numNonTerminals, Eq(exp1, exp2)) :- 
+    constraintExpOk(s, numNonTerminals, exp1),
+    constraintExpOk(s, numNonTerminals, exp2).
+  constraintOk(s, numNonTerminals, Lt(exp1, exp2)) :- 
+    constraintExpOk(s, numNonTerminals, exp1),
+    constraintExpOk(s, numNonTerminals, exp2).
+  constraintOk(s, numNonTerminals, Le(exp1, exp2)) :- 
+    constraintExpOk(s, numNonTerminals, exp1),
+    constraintExpOk(s, numNonTerminals, exp2).
+  constraintOk(s, numNonTerminals, Gt(exp1, exp2)) :- 
+    constraintExpOk(s, numNonTerminals, exp1),
+    constraintExpOk(s, numNonTerminals, exp2).
+  constraintOk(s, numNonTerminals, Ge(exp1, exp2)) :- 
+    constraintExpOk(s, numNonTerminals, exp1),
+    constraintExpOk(s, numNonTerminals, exp2).
+  constraintOk(s, numNonTerminals, Not(c)) :- 
+    constraintOk(s, numNonTerminals, c).
+  constraintOk(s, numNonTerminals, And(c1, c2)) :- 
+    constraintOk(s, numNonTerminals, c1),
+    constraintOk(s, numNonTerminals, c2).
+  constraintOk(s, numNonTerminals, Or(c1, c2)) :- 
+    constraintOk(s, numNonTerminals, c1),
+    constraintOk(s, numNonTerminals, c2).
+  
+  constraintOk(s, numNonTerminals, Offside(ref, refs)) :- 
+    constraintTreeRefOk(s, numNonTerminals, ref),
+    constraintTreeRefsOk(s, numNonTerminals, refs).
+  constraintOk(s, numNonTerminals, Indent(ref, refs)) :- 
+    constraintTreeRefOk(s, numNonTerminals, ref),
+    constraintTreeRefsOk(s, numNonTerminals, refs).
+  constraintOk(s, numNonTerminals, Align(ref, refs)) :- 
+    constraintTreeRefOk(s, numNonTerminals, ref),
+    constraintTreeRefsOk(s, numNonTerminals, refs).
+  constraintOk(s, numNonTerminals, AlignList(ref)) :- 
+    constraintTreeRefOk(s, numNonTerminals, ref).
+  constraintOk(s, numNonTerminals, NewLineIndent(ref, refs)) :- 
+    constraintTreeRefOk(s, numNonTerminals, ref),
+    constraintTreeRefsOk(s, numNonTerminals, refs).
+  constraintOk(s, numNonTerminals, SingleLine(refs)) :- 
+    constraintTreeRefsOk(s, numNonTerminals, refs).
+
+  constraintOk(s, numNonTerminals, PPOffside(ref, refs)) :- 
+    constraintTreeRefOk(s, numNonTerminals, ref),
+    constraintTreeRefsOk(s, numNonTerminals, refs).
+  constraintOk(s, numNonTerminals, PPIndent(ref, refs)) :- 
+    constraintTreeRefOk(s, numNonTerminals, ref),
+    constraintTreeRefsOk(s, numNonTerminals, refs).
+  constraintOk(s, numNonTerminals, PPAlign(ref, refs)) :- 
+    constraintTreeRefOk(s, numNonTerminals, ref),
+    constraintTreeRefsOk(s, numNonTerminals, refs).
+  constraintOk(s, numNonTerminals, PPAlignList(ref)) :- 
+    constraintTreeRefOk(s, numNonTerminals, ref).
+  constraintOk(s, numNonTerminals, PPNewLineIndent(ref, refs)) :- 
+    constraintTreeRefOk(s, numNonTerminals, ref),
+    constraintTreeRefsOk(s, numNonTerminals, refs).
+  constraintOk(s, numNonTerminals, PPNewLineIndentBy(Digits(index), ref, refs)) :- 
+    constraintTreeRefOk(s, numNonTerminals, ref),
+    constraintTreeRefsOk(s, numNonTerminals, refs).
+    // TODO: check index
+  constraintOk(s, numNonTerminals, PPNewLine(ref)) :- 
+    constraintTreeRefOk(s, numNonTerminals, ref).
+  constraintOk(s, numNonTerminals, PPNewLineBy(Digits(index), ref)) :- 
+    constraintTreeRefOk(s, numNonTerminals, ref).
+    // TODO: check index
+          
 rules
 
   hasAttribute: Attribute * Attributes -> BOOL

--- a/org.metaborg.meta.lang.template/trans/statix/check.str
+++ b/org.metaborg.meta.lang.template/trans/statix/check.str
@@ -1,0 +1,29 @@
+module statix/check
+
+imports
+
+  signatures/-
+
+signature constructors
+
+  Message : Term * string -> Message
+
+rules
+
+  spoofax3-check: 
+    ast -> (errors, warnings, notes)
+    with
+      errors   := <collect-all(spoofax3-collect-error, conc)> ast
+    ; warnings := <collect-all(spoofax3-collect-warning, conc)> ast
+    ; notes    := <collect-all(spoofax3-collect-note, conc)> ast
+  
+  spoofax3-collect-note = fail
+  spoofax3-collect-warning = fail
+  spoofax3-collect-error = fail
+  
+rules
+
+  spoofax3-collect-error: 
+    SortCons(_, Constructor(constructorName)) -> Message(constructorName, $[Constructor '[constructorName]' does not start with a capital character])
+    where
+      <explode-string; Hd; is-lower>  constructorName

--- a/org.metaborg.meta.lang.template/trans/statix/cons.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/cons.stx
@@ -12,8 +12,11 @@ rules // Constructor reusable predicates
   declareConstructor(s, Tsymbols, Tsort, name) = Tprod :- {results}
     Tprod == PROD(Tsymbols, Tsort),
     s -> Constructor{name} with typeOfDecl Tprod,
-    typeOfDecl of Constructor{name} in s |-> results,
-    onlyOneOf(Tprod, results) | error $[Duplicate definition of constructor [name]]@name,
+    //typeOfDecl of Constructor{name} in s |-> results,
+    //onlyOneOf(Tprod, results) | error $[Duplicate definition of constructor [name]]@name,
+    // Check if constructor is globally unique, as Statix currently does not support the use of duplicate constructors
+    // even if they are defined on a different sort.
+    Constructor{name} in s |-> [(_, (_))] | error $[Constructor [name] is already defined],
     @name.type := Tprod.
 
   typeOfConstructor : scope * string -> TYPE

--- a/org.metaborg.meta.lang.template/trans/statix/constant.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/constant.stx
@@ -1,0 +1,14 @@
+module statix/constant
+
+signature
+
+  sorts IdCon constructors
+    Default : string -> IdCon
+    
+  sorts StrCon constructors
+    // TODO: rename constructor in pre/post analyze.
+    // Default : string -> StrCon
+  
+  sorts NatCon constructors
+    Digits : int -> NatCon // TODO: it is a string in the AST, can this be int?
+  

--- a/org.metaborg.meta.lang.template/trans/statix/main.str
+++ b/org.metaborg.meta.lang.template/trans/statix/main.str
@@ -15,7 +15,7 @@ imports
 
 rules // Editor
 
-  statix-editor-analyze = stx-editor-analyze(statix-pre, statix-post|"statix/main", "projectOK", "fileOK")
+  statix-editor-analyze = stx-editor-analyze(pre-analyze, post-analyze|"statix/main", "projectOK", "fileOK")
 
   statix-editor-resolve = stx-editor-resolve
 
@@ -67,18 +67,18 @@ rules // Debugging
     (selected, position, ast, path, project-path) -> (filename, result)
     with
       filename := <guarantee-extension(|"statix-pre-transformed.aterm")> path;
-      result   := <statix-pre> selected
+      result   := <pre-analyze> selected
 
   statix-debug-show-pre-post-transformed:
     (selected, position, ast, path, project-path) -> (filename, result)
     with
       filename := <guarantee-extension(|"statix-pre-post-transformed.aterm")> path;
-      result   := <statix-pre; statix-post> selected
+      result   := <pre-analyze; post-analyze> selected
 
 rules // Statix pre and post-transformation
 
-  statix-pre  = lift-all; explicate-all-injections; disambiguate-all-constructors
-  statix-post = ambiguate-all-constructors; unexplicate-all-injections
+  pre-analyze  = lift-all; explicate-all-injections; disambiguate-all-constructors
+  post-analyze = ambiguate-all-constructors; unexplicate-all-injections
 
   explicate-all-injections   = topdown(try(  explicate-injection))
   unexplicate-all-injections = topdown(try(unexplicate-injection))

--- a/org.metaborg.meta.lang.template/trans/statix/main.str
+++ b/org.metaborg.meta.lang.template/trans/statix/main.str
@@ -28,6 +28,7 @@ signature constructors // Types
   INJ      : list(TYPE) * TYPE -> TYPE
   ITER     : TYPE              -> TYPE
   TERMINAL : TYPE
+  LAYOUT   : TYPE
 
 rules // Types
 
@@ -40,7 +41,7 @@ rules // Types
 
   fail-msg(|msg) = err-msg(|$[get-type: [msg]]); fail
 
-  remove-unnecessary-types = remove-all(?TERMINAL())
+  remove-unnecessary-types = remove-all(?TERMINAL() + ?LAYOUT())
 
   to-compatible-type:
     SORT(occ) -> SortType(<stx-get-occurrence-terms; Hd> occ)

--- a/org.metaborg.meta.lang.template/trans/statix/main.str
+++ b/org.metaborg.meta.lang.template/trans/statix/main.str
@@ -28,11 +28,11 @@ signature constructors // Types
   SORT     : Occurrence        -> TYPE
   PROD     : list(TYPE) * TYPE -> TYPE
   INJ      : list(TYPE) * TYPE -> TYPE
-  
+
   ITER     : TYPE              -> TYPE
   TERMINAL : TYPE
   LAYOUT   : TYPE
-  
+
   SEQ      : TYPE * list(TYPE) -> TYPE
   OPT      : TYPE              -> TYPE
   ALT      : TYPE * TYPE       -> TYPE
@@ -55,11 +55,11 @@ rules // Types
   is-concrete-syntax-type: OPT(t) -> <is-concrete-syntax-type> t
   is-concrete-syntax-type: ALT(t, _) -> <is-concrete-syntax-type> t
   is-concrete-syntax-type: ALT(_, t) -> <is-concrete-syntax-type> t
-  
+
   is-legacy-type = ?SEQ(_, _)
   is-legacy-type = ?OPT(_)
   is-legacy-type = ?ALT(_, _)
-   
+
   remove-unnecessary-types = remove-all(is-concrete-syntax-type <+ is-legacy-type)
 
   to-compatible-type:
@@ -159,14 +159,18 @@ rules
   explicate-injection = TemplateProduction        (explicate-symboldef, id, id)
   explicate-injection = TemplateProductionWithCons(explicate-injection, id, id)
   explicate-injection = KeywordAttributes         (explicate-symboldef, id)
-  unexplicate-injection = SdfProduction             (unexplicate-symboldef, id, id)
+  unexplicate-injection = SdfProduction             (bottomup(try(unexplicate-symboldef)), id, id)
   unexplicate-injection = SdfProductionWithCons     (unexplicate-injection, id, id)
-  unexplicate-injection = TemplateProduction        (unexplicate-symboldef, id, id)
+  unexplicate-injection = TemplateProduction        (bottomup(try(unexplicate-symboldef)), id, id)
   unexplicate-injection = TemplateProductionWithCons(unexplicate-injection, id, id)
-  unexplicate-injection = KeywordAttributes         (unexplicate-symboldef, id)
+  unexplicate-injection = KeywordAttributes         (bottomup(try(unexplicate-symboldef)), id)
 
   explicate-symboldef: symbol -> SymbolDef_Symbol(symbol)
   where <not(?SortDef(_) <+ ?Cf(_) <+ ?Lex(_) <+ ?Var(_))> symbol
+  explicate-symboldef = Cf(explicate-symboldef)
+  explicate-symboldef = Lex(explicate-symboldef)
+  explicate-symboldef = Var(explicate-symboldef)
+  explicate-symboldef = ?SortDef(_)
   unexplicate-symboldef: SymbolDef_Symbol(symbol) -> symbol
 
 signature constructors // SymbolDef and ambiguous constructors
@@ -201,7 +205,7 @@ rules
 signature constructors // Layout constraints line
 
   ConstraintExpLine : ConstraintToken -> ConstraintExp
-  
+
 rules
 
   disambiguate-constructor = Attrs(topdown(try(disambiguate-constraint-line-constructor)))

--- a/org.metaborg.meta.lang.template/trans/statix/main.str
+++ b/org.metaborg.meta.lang.template/trans/statix/main.str
@@ -8,6 +8,7 @@ imports
   signatures/-
   signatures/sorts/Sorts-sig
   signatures/priority/Priority-sig
+  signatures/kernel/-
 
 imports
 
@@ -178,3 +179,14 @@ rules
   ambiguate-symboldef-constructor: SymbolDefCf (symbolDef) -> Cf (symbolDef)
   ambiguate-symboldef-constructor: SymbolDefLex(symbolDef) -> Lex(symbolDef)
   ambiguate-symboldef-constructor: SymbolDefVar(symbolDef) -> Var(symbolDef)
+
+signature constructors // Layout constraints line
+
+  ConstraintExpLine : ConstraintToken -> ConstraintExp
+  
+rules
+
+  disambiguate-constructor = Attrs(topdown(try(disambiguate-constraint-line-constructor)))
+  disambiguate-constraint-line-constructor: Line(token) -> ConstraintExpLine(token)
+  ambiguate-constructor = Attrs(topdown(try(ambiguate-constraint-line-constructor)))
+  ambiguate-constraint-line-constructor: ConstraintExpLine(token) -> Line(token)

--- a/org.metaborg.meta.lang.template/trans/statix/main.str
+++ b/org.metaborg.meta.lang.template/trans/statix/main.str
@@ -9,6 +9,7 @@ imports
   signatures/sorts/Sorts-sig
   signatures/priority/Priority-sig
   signatures/kernel/-
+  statix/check
 
 imports
 

--- a/org.metaborg.meta.lang.template/trans/statix/main.str
+++ b/org.metaborg.meta.lang.template/trans/statix/main.str
@@ -28,9 +28,14 @@ signature constructors // Types
   SORT     : Occurrence        -> TYPE
   PROD     : list(TYPE) * TYPE -> TYPE
   INJ      : list(TYPE) * TYPE -> TYPE
+  
   ITER     : TYPE              -> TYPE
   TERMINAL : TYPE
   LAYOUT   : TYPE
+  
+  SEQ      : TYPE * list(TYPE) -> TYPE
+  OPT      : TYPE              -> TYPE
+  ALT      : TYPE * TYPE       -> TYPE
 
 rules // Types
 
@@ -43,7 +48,19 @@ rules // Types
 
   fail-msg(|msg) = err-msg(|$[get-type: [msg]]); fail
 
-  remove-unnecessary-types = remove-all(?TERMINAL() + ?LAYOUT())
+  is-concrete-syntax-type = ?TERMINAL()
+  is-concrete-syntax-type = ?LAYOUT()
+  is-concrete-syntax-type: SEQ(t, _) -> <is-concrete-syntax-type> t
+  is-concrete-syntax-type: SEQ(_, ts) -> <one(is-concrete-syntax-type)> ts
+  is-concrete-syntax-type: OPT(t) -> <is-concrete-syntax-type> t
+  is-concrete-syntax-type: ALT(t, _) -> <is-concrete-syntax-type> t
+  is-concrete-syntax-type: ALT(_, t) -> <is-concrete-syntax-type> t
+  
+  is-legacy-type = ?SEQ(_, _)
+  is-legacy-type = ?OPT(_)
+  is-legacy-type = ?ALT(_, _)
+   
+  remove-unnecessary-types = remove-all(is-concrete-syntax-type <+ is-legacy-type)
 
   to-compatible-type:
     SORT(occ) -> SortType(<stx-get-occurrence-terms; Hd> occ)

--- a/org.metaborg.meta.lang.template/trans/statix/main.str
+++ b/org.metaborg.meta.lang.template/trans/statix/main.str
@@ -190,3 +190,8 @@ rules
   disambiguate-constraint-line-constructor: Line(token) -> ConstraintExpLine(token)
   ambiguate-constructor = Attrs(topdown(try(ambiguate-constraint-line-constructor)))
   ambiguate-constraint-line-constructor: ConstraintExpLine(token) -> Line(token)
+
+rules // PosRef contents to int
+
+  disambiguate-constructor = PosRef(string-to-int)
+  ambiguate-constructor = PosRef(int-to-string)

--- a/org.metaborg.meta.lang.template/trans/statix/production.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/production.stx
@@ -11,25 +11,35 @@ imports
 rules // SymbolDef (no constructor) production checks
 
   symbolDefProductionOK: SORT_KIND * TYPE * Attributes * SymbolDef
-  
-  symbolDefProductionOK(CONTEXTFREE(), INJ(ts@[_, _, _|_], SORT(_)), attrs, symbolDef) :-
+
+  symbolDefProductionOK(CONTEXTFREE(), INJ(ts@[TERMINAL(), SORT(_), TERMINAL()], SORT(_)), attrs, symbolDef) :-
     try { 
       bOr(hasAttribute(Reject(), attrs), hasAttribute(Bracket(), attrs)) == TRUE()
-    } | error $[Missing constructor; add a constructor to this production, turn it into an injection in the form of A = B, or turn it into a bracket rule in the form of A = "(" A ")" {bracket}]@symbolDef,
+    } | error $[Missing constructor; add a constructor to this production, turn it into an injection in the form of A = B, or turn it into a bracket production in the form of A = "(" B ")" {bracket}]@symbolDef,
     symbolDefCheckForLegacyTypesInContextFree(ts, symbolDef).
-    
-  symbolDefProductionOK(CONTEXTFREE(), INJ(ts@[_, _|_], SORT(_)), attrs, symbolDef) :-
+
+  symbolDefProductionOK(CONTEXTFREE(), INJ(ts@[SORT(_)], SORT(_)), attrs, symbolDef) :- // Correct injection
+    symbolDefCheckForLegacyTypesInContextFree(ts, symbolDef).
+  symbolDefProductionOK(CONTEXTFREE(), INJ(ts@[ITER(_)], SORT(_)), attrs, symbolDef) :- // Correct injection
+    symbolDefCheckForLegacyTypesInContextFree(ts, symbolDef).
+
+  symbolDefProductionOK(CONTEXTFREE(), INJ(ts, SORT(_)), attrs, symbolDef) :-
     try { 
       bOr(hasAttribute(Reject(), attrs), hasAttribute(Bracket(), attrs)) == TRUE()
-    } | error $[Missing constructor; either add a constructor to this production, or turn it into an injection in the form of A = B]@symbolDef,
+    } | error $[Missing constructor; add a constructor to this production]@symbolDef,
+    symbolDefCheckForCorrectBracketUsage(ts, attrs, symbolDef),
     symbolDefCheckForLegacyTypesInContextFree(ts, symbolDef).
-  symbolDefProductionOK(CONTEXTFREE(), INJ(ts, _), _, symbolDef) :-
+
+  symbolDefProductionOK(CONTEXTFREE(), INJ(ts, _), attrs, symbolDef) :-
+    symbolDefCheckForCorrectBracketUsage(ts, attrs, symbolDef),
     symbolDefCheckForLegacyTypesInContextFree(ts, symbolDef).
+
 
   symbolDefProductionOK(LEXICAL(), _, attrs, symbolDef) :-
     try { hasAttribute(Bracket(), attrs) == FALSE() } | error $[Bracket in lexical syntax; remove the bracket annotation from the production]@symbolDef.
 
   symbolDefProductionOK(_, _, _, _).
+
 
 rules // SortCons (constructor) production checks
 
@@ -38,13 +48,25 @@ rules // SortCons (constructor) production checks
   sortConsProductionOK(CONTEXTFREE(), PROD(ts, _), attrs, sortCons) :-
     try { hasAttribute(Bracket(), attrs) == FALSE() } | error $[Bracket annotation on production with a constructor; either remove the constructor or the bracket annotation from the production]@sortCons,
     sortConsCheckForLegacyTypesInContextFree(ts, sortCons).
+
+
   sortConsProductionOK(LEXICAL(), PROD(_, _), attrs, sortCons) :-
     try { false } | warning $[Constructor in lexical syntax; remove this constructor from the production]@sortCons,
     try { hasAttribute(Bracket(), attrs) == FALSE() } | error $[Bracket in lexical syntax; remove the bracket annotation from the production]@sortCons.
-  
+
   sortConsProductionOK(_, _, _, _).
 
-rules // Check for legacy symbols in context-free syntax 
+
+rules // Check for correct bracket usage
+
+  symbolDefCheckForCorrectBracketUsage: list(TYPE) * Attributes * SymbolDef
+  symbolDefCheckForCorrectBracketUsage([TERMINAL(), SORT(_), TERMINAL()], _, _). // Correct bracket usage
+  symbolDefCheckForCorrectBracketUsage(_, attrs, symbolDef) :-
+    try { 
+      bOr(hasAttribute(Reject(), attrs), bNot(hasAttribute(Bracket(), attrs))) == TRUE()
+    } | error $[Incorrect bracket production; either turn it into a regular production, or a bracket production in the form of A = "(" B ")"]@symbolDef.
+
+rules // Check for legacy symbols in context-free syntax
 
   symbolDefCheckForLegacyTypesInContextFree: list(TYPE) * SymbolDef
   symbolDefCheckForLegacyTypesInContextFree(ts, symbolDef) :- 
@@ -57,7 +79,8 @@ rules // Check for legacy symbols in context-free syntax
     try { listContainsOpt(ts) == FALSE() } | error $[Optionals (A?) are not allowed in context-free syntax]@sortCons,
     try { listContainsAlt(ts) == FALSE() } | error $[Alternations (A | B) are not allowed in context-free syntax]@sortCons,
     try { listContainsSeq(ts) == FALSE() } | error $[Sequences ((A B ... Z)) are not allowed in context-free syntax]@sortCons.
-    
+
+
 rules // Opt symbol checking
 
   typeIsOrContainsOpt: TYPE -> BOOL
@@ -77,6 +100,7 @@ rules // Opt symbol checking
   listContainsOpt([t|ts]) = bOr(typeIsOrContainsOpt(t), listContainsOpt(ts)).
   listContainsOpt([])     = FALSE().
 
+
 rules // Alt symbol checking
 
   typeIsOrContainsAlt: TYPE -> BOOL
@@ -95,6 +119,7 @@ rules // Alt symbol checking
   listContainsAlt: list(TYPE) -> BOOL
   listContainsAlt([t|ts]) = bOr(typeIsOrContainsAlt(t), listContainsAlt(ts)).
   listContainsAlt([])     = FALSE().
+
 
 rules // Seq symbol checking
 

--- a/org.metaborg.meta.lang.template/trans/statix/production.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/production.stx
@@ -8,7 +8,7 @@ imports
   statix/attribute
   statix/sort_cons
 
-rules
+rules // SymbolDef (no constructor) production checks
 
   symbolDefProductionOK: SORT_KIND * TYPE * Attributes * SymbolDef
   
@@ -16,49 +16,101 @@ rules
     try { 
       bOr(hasAttribute(Reject(), attrs), hasAttribute(Bracket(), attrs)) == TRUE()
     } | error $[Missing constructor; add a constructor to this production, turn it into an injection in the form of A = B, or turn it into a bracket rule in the form of A = "(" A ")" {bracket}]@symbolDef,
-    try { containsOpt(ts) == FALSE() } | error $[Optionals (A?) are not allowed in context-free syntax]@symbolDef,
-    try { containsAlt(ts) == FALSE() } | error $[Alternations (A | B) are not allowed in context-free syntax]@symbolDef,
-    try { containsSeq(ts) == FALSE() } | error $[Sequences ((A B ... Z)) are not allowed in context-free syntax]@symbolDef.
+    symbolDefCheckForLegacyTypesInContextFree(ts, symbolDef).
+    
   symbolDefProductionOK(CONTEXTFREE(), INJ(ts@[_, _|_], SORT(_)), attrs, symbolDef) :-
     try { 
       bOr(hasAttribute(Reject(), attrs), hasAttribute(Bracket(), attrs)) == TRUE()
     } | error $[Missing constructor; either add a constructor to this production, or turn it into an injection in the form of A = B]@symbolDef,
-    try { containsOpt(ts) == FALSE() } | error $[Optionals (A?) are not allowed in context-free syntax]@symbolDef,
-    try { containsAlt(ts) == FALSE() } | error $[Alternations (A | B) are not allowed in context-free syntax]@symbolDef,
-    try { containsSeq(ts) == FALSE() } | error $[Sequences ((A B ... Z)) are not allowed in context-free syntax]@symbolDef.
+    symbolDefCheckForLegacyTypesInContextFree(ts, symbolDef).
   symbolDefProductionOK(CONTEXTFREE(), INJ(ts, _), _, symbolDef) :-
-    try { containsOpt(ts) == FALSE() } | error $[Optionals (A?) are not allowed in context-free syntax]@symbolDef,
-    try { containsAlt(ts) == FALSE() } | error $[Alternations (A | B) are not allowed in context-free syntax]@symbolDef,
-    try { containsSeq(ts) == FALSE() } | error $[Sequences ((A B ... Z)) are not allowed in context-free syntax]@symbolDef.
-    
+    symbolDefCheckForLegacyTypesInContextFree(ts, symbolDef).
+
+  symbolDefProductionOK(LEXICAL(), _, attrs, symbolDef) :-
+    try { hasAttribute(Bracket(), attrs) == FALSE() } | error $[Bracket in lexical syntax; remove the bracket annotation from the production]@symbolDef.
+
   symbolDefProductionOK(_, _, _, _).
 
-rules
+rules // SortCons (constructor) production checks
 
   sortConsProductionOK: SORT_KIND * TYPE * Attributes * SortCons
 
-  sortConsProductionOK(CONTEXTFREE(), PROD(ts, _), _, sortCons) :-
-    try { containsOpt(ts) == FALSE() } | error $[Optionals (A?) are not allowed in context-free syntax]@sortCons,
-    try { containsAlt(ts) == FALSE() } | error $[Alternations (A | B) are not allowed in context-free syntax]@sortCons,
-    try { containsSeq(ts) == FALSE() } | error $[Sequences ((A B ... Z)) are not allowed in context-free syntax]@sortCons.
-  sortConsProductionOK(LEXICAL(), PROD(_, _), _, sortCons) :-
-    try { false } | warning $[Constructor in lexical syntax; remove this constructor from the production]@sortCons.
+  sortConsProductionOK(CONTEXTFREE(), PROD(ts, _), attrs, sortCons) :-
+    try { hasAttribute(Bracket(), attrs) == FALSE() } | error $[Bracket annotation on production with a constructor; either remove the constructor or the bracket annotation from the production]@sortCons,
+    sortConsCheckForLegacyTypesInContextFree(ts, sortCons).
+  sortConsProductionOK(LEXICAL(), PROD(_, _), attrs, sortCons) :-
+    try { false } | warning $[Constructor in lexical syntax; remove this constructor from the production]@sortCons,
+    try { hasAttribute(Bracket(), attrs) == FALSE() } | error $[Bracket in lexical syntax; remove the bracket annotation from the production]@sortCons.
   
   sortConsProductionOK(_, _, _, _).
 
-rules
+rules // Check for legacy symbols in context-free syntax 
 
-  containsOpt: list(TYPE) -> BOOL
-  containsOpt([OPT(_)|ts]) = TRUE().
-  containsOpt([_|ts])      = containsOpt(ts).
-  containsOpt([])          = FALSE().
-  
-  containsAlt: list(TYPE) -> BOOL
-  containsAlt([ALT(_, _)|ts]) = TRUE().
-  containsAlt([_|ts])         = containsAlt(ts).
-  containsAlt([])             = FALSE().
-  
-  containsSeq: list(TYPE) -> BOOL
-  containsSeq([SEQ(_, _)|ts]) = TRUE().
-  containsSeq([_|ts])         = containsSeq(ts).
-  containsSeq([])             = FALSE().
+  symbolDefCheckForLegacyTypesInContextFree: list(TYPE) * SymbolDef
+  symbolDefCheckForLegacyTypesInContextFree(ts, symbolDef) :- 
+    try { listContainsOpt(ts) == FALSE() } | error $[Optionals (A?) are not allowed in context-free syntax]@symbolDef,
+    try { listContainsAlt(ts) == FALSE() } | error $[Alternations (A | B) are not allowed in context-free syntax]@symbolDef,
+    try { listContainsSeq(ts) == FALSE() } | error $[Sequences ((A B ... Z)) are not allowed in context-free syntax]@symbolDef.
+
+  sortConsCheckForLegacyTypesInContextFree: list(TYPE) * SortCons
+  sortConsCheckForLegacyTypesInContextFree(ts, sortCons) :- 
+    try { listContainsOpt(ts) == FALSE() } | error $[Optionals (A?) are not allowed in context-free syntax]@sortCons,
+    try { listContainsAlt(ts) == FALSE() } | error $[Alternations (A | B) are not allowed in context-free syntax]@sortCons,
+    try { listContainsSeq(ts) == FALSE() } | error $[Sequences ((A B ... Z)) are not allowed in context-free syntax]@sortCons.
+    
+rules // Opt symbol checking
+
+  typeIsOrContainsOpt: TYPE -> BOOL
+  typeIsOrContainsOpt(OPT(_))      = TRUE().
+  typeIsOrContainsOpt(SEQ(t, ts))  = bOr(isOpt(t), listContainsOpt(ts)).
+  typeIsOrContainsOpt(ITER(t))     = typeIsOrContainsOpt(t).
+  typeIsOrContainsOpt(ALT(t1, t2)) = bOr(isOpt(t1), isOpt(t2)).
+  typeIsOrContainsOpt(PROD(ts, t)) = bOr(listContainsOpt(ts), isOpt(t)).
+  typeIsOrContainsOpt(INJ(ts, t))  = bOr(listContainsOpt(ts), isOpt(t)).
+  typeIsOrContainsOpt(_)           = FALSE().
+
+  isOpt: TYPE -> BOOL
+  isOpt(OPT(_)) = TRUE().
+  isOpt(_)      = FALSE().
+
+  listContainsOpt: list(TYPE) -> BOOL
+  listContainsOpt([t|ts]) = bOr(typeIsOrContainsOpt(t), listContainsOpt(ts)).
+  listContainsOpt([])     = FALSE().
+
+rules // Alt symbol checking
+
+  typeIsOrContainsAlt: TYPE -> BOOL
+  typeIsOrContainsAlt(ALT(_, _))   = TRUE().
+  typeIsOrContainsAlt(SEQ(t, ts))  = bOr(isAlt(t), listContainsAlt(ts)).
+  typeIsOrContainsAlt(ITER(t))     = typeIsOrContainsAlt(t).
+  typeIsOrContainsAlt(OPT(t))      = isAlt(t).
+  typeIsOrContainsAlt(PROD(ts, t)) = bOr(listContainsAlt(ts), isAlt(t)).
+  typeIsOrContainsAlt(INJ(ts, t))  = bOr(listContainsAlt(ts), isAlt(t)).
+  typeIsOrContainsAlt(_)           = FALSE().
+
+  isAlt: TYPE -> BOOL
+  isAlt(ALT(_, _)) = TRUE().
+  isAlt(_)         = FALSE().
+
+  listContainsAlt: list(TYPE) -> BOOL
+  listContainsAlt([t|ts]) = bOr(typeIsOrContainsAlt(t), listContainsAlt(ts)).
+  listContainsAlt([])     = FALSE().
+
+rules // Seq symbol checking
+
+  typeIsOrContainsSeq: TYPE -> BOOL
+  typeIsOrContainsSeq(SEQ(_, _))   = TRUE().
+  typeIsOrContainsSeq(OPT(t))      = isSeq(t).
+  typeIsOrContainsSeq(ITER(t))     = typeIsOrContainsSeq(t).
+  typeIsOrContainsSeq(ALT(t1, t2)) = bOr(isSeq(t1), isSeq(t2)).
+  typeIsOrContainsSeq(PROD(ts, t)) = bOr(listContainsSeq(ts), isSeq(t)).
+  typeIsOrContainsSeq(INJ(ts, t))  = bOr(listContainsSeq(ts), isSeq(t)).
+  typeIsOrContainsSeq(_)           = FALSE().
+
+  isSeq: TYPE -> BOOL
+  isSeq(SEQ(_, _)) = TRUE().
+  isSeq(_)         = FALSE().
+
+  listContainsSeq: list(TYPE) -> BOOL
+  listContainsSeq([t|ts]) = bOr(typeIsOrContainsSeq(t), listContainsSeq(ts)).
+  listContainsSeq([])     = FALSE().

--- a/org.metaborg.meta.lang.template/trans/statix/production.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/production.stx
@@ -2,30 +2,63 @@ module statix/production
 
 imports
 
+  statix/util
+  statix/name
   statix/type
   statix/attribute
   statix/sort_cons
 
 rules
 
-  injectionProductionOK: TYPE * Attributes * SymbolDef
-  // Disabled for now: produces spurious errors in some cases.
-  //injectionProductionOK(PROD([_, _|_], SORT(_)), attrs, loc) :-
-  //  try { hasAttribute(Reject(), attrs) == TRUE() } | warning $[Missing constructor name: the generated pretty printer might not work properly] @loc.
-  injectionProductionOK(_, _, _).
+  symbolDefProductionOK: SORT_KIND * TYPE * Attributes * SymbolDef
+  
+  symbolDefProductionOK(CONTEXTFREE(), INJ(ts@[_, _, _|_], SORT(_)), attrs, symbolDef) :-
+    try { 
+      bOr(hasAttribute(Reject(), attrs), hasAttribute(Bracket(), attrs)) == TRUE()
+    } | error $[Missing constructor; add a constructor to this production, turn it into an injection in the form of A = B, or turn it into a bracket rule in the form of A = "(" A ")" {bracket}]@symbolDef,
+    try { containsOpt(ts) == FALSE() } | error $[Optionals (A?) are not allowed in context-free syntax]@symbolDef,
+    try { containsAlt(ts) == FALSE() } | error $[Alternations (A | B) are not allowed in context-free syntax]@symbolDef,
+    try { containsSeq(ts) == FALSE() } | error $[Sequences ((A B ... Z)) are not allowed in context-free syntax]@symbolDef.
+  symbolDefProductionOK(CONTEXTFREE(), INJ(ts@[_, _|_], SORT(_)), attrs, symbolDef) :-
+    try { 
+      bOr(hasAttribute(Reject(), attrs), hasAttribute(Bracket(), attrs)) == TRUE()
+    } | error $[Missing constructor; either add a constructor to this production, or turn it into an injection in the form of A = B]@symbolDef,
+    try { containsOpt(ts) == FALSE() } | error $[Optionals (A?) are not allowed in context-free syntax]@symbolDef,
+    try { containsAlt(ts) == FALSE() } | error $[Alternations (A | B) are not allowed in context-free syntax]@symbolDef,
+    try { containsSeq(ts) == FALSE() } | error $[Sequences ((A B ... Z)) are not allowed in context-free syntax]@symbolDef.
+  symbolDefProductionOK(CONTEXTFREE(), INJ(ts, _), _, symbolDef) :-
+    try { containsOpt(ts) == FALSE() } | error $[Optionals (A?) are not allowed in context-free syntax]@symbolDef,
+    try { containsAlt(ts) == FALSE() } | error $[Alternations (A | B) are not allowed in context-free syntax]@symbolDef,
+    try { containsSeq(ts) == FALSE() } | error $[Sequences ((A B ... Z)) are not allowed in context-free syntax]@symbolDef.
+    
+  symbolDefProductionOK(_, _, _, _).
 
-  // TODO: error: Missing bracket attribute or constructor name
-  // - LHS must be a single sort (injection)
-  // - RHS must be in the form of '(' Sort ')'
-  // - attributes must NOT contain Bracket() nor Reject()
+rules
 
-  // TODO: warning: Illegal use of the {bracket} attribute
-  // - HS must be a single sort (injection)
-  // - RHS must NOT be in the form of '(' Sort ')'
-  // - attributes must contain Bracket()
-  // - attributes must NOT contain Reject()
+  sortConsProductionOK: SORT_KIND * TYPE * Attributes * SortCons
 
-  // TODO: warning: Illegal use of the {bracket} attribute
-  // - LHS must be a sort + constructor (not an injection)
-  // - attributes must contain Bracket()
-  // - attributes must NOT contain Reject()
+  sortConsProductionOK(CONTEXTFREE(), PROD(ts, _), _, sortCons) :-
+    try { containsOpt(ts) == FALSE() } | error $[Optionals (A?) are not allowed in context-free syntax]@sortCons,
+    try { containsAlt(ts) == FALSE() } | error $[Alternations (A | B) are not allowed in context-free syntax]@sortCons,
+    try { containsSeq(ts) == FALSE() } | error $[Sequences ((A B ... Z)) are not allowed in context-free syntax]@sortCons.
+  sortConsProductionOK(LEXICAL(), PROD(_, _), _, sortCons) :-
+    try { false } | warning $[Constructor in lexical syntax; remove this constructor from the production]@sortCons.
+  
+  sortConsProductionOK(_, _, _, _).
+
+rules
+
+  containsOpt: list(TYPE) -> BOOL
+  containsOpt([OPT(_)|ts]) = TRUE().
+  containsOpt([_|ts])      = containsOpt(ts).
+  containsOpt([])          = FALSE().
+  
+  containsAlt: list(TYPE) -> BOOL
+  containsAlt([ALT(_, _)|ts]) = TRUE().
+  containsAlt([_|ts])         = containsAlt(ts).
+  containsAlt([])             = FALSE().
+  
+  containsSeq: list(TYPE) -> BOOL
+  containsSeq([SEQ(_, _)|ts]) = TRUE().
+  containsSeq([_|ts])         = containsSeq(ts).
+  containsSeq([])             = FALSE().

--- a/org.metaborg.meta.lang.template/trans/statix/section/priority.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/section/priority.stx
@@ -61,5 +61,5 @@ rules
   priorityProductionOK: scope * PriorityProduction
   // TODO: these should not declare new productions, but instead should be checked against existing ones?
   priorityProductionOK(s, PriorityProduction_SdfProduction(sdfProduction)) :- typeOfSdfProduction(s, CONTEXTFREE(), sdfProduction) == _.
-  priorityProductionOK(s, PriorityProduction_Production(production))       :- productionOK(s, CONTEXTFREE(), production).
+  priorityProductionOK(s, PriorityProduction_Production(production))       :- kernelProductionOK(s, CONTEXTFREE(), production).
   priorityProductionsOK maps priorityProductionOK(*, list(*))

--- a/org.metaborg.meta.lang.template/trans/statix/section/priority.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/section/priority.stx
@@ -60,6 +60,6 @@ rules
 
   priorityProductionOK: scope * PriorityProduction
   // TODO: these should not declare new productions, but instead should be checked against existing ones?
-  priorityProductionOK(s, PriorityProduction_SdfProduction(sdfProduction)) :- typeOfSdfProduction(s, sdfProduction) == _.
-  priorityProductionOK(s, PriorityProduction_Production(production))       :- productionOK(s, production).
+  priorityProductionOK(s, PriorityProduction_SdfProduction(sdfProduction)) :- typeOfSdfProduction(s, CONTEXTFREE(), sdfProduction) == _.
+  priorityProductionOK(s, PriorityProduction_Production(production))       :- productionOK(s, CONTEXTFREE(), production).
   priorityProductionsOK maps priorityProductionOK(*, list(*))

--- a/org.metaborg.meta.lang.template/trans/statix/section/syntax.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/section/syntax.stx
@@ -77,9 +77,8 @@ rules
     typesOfSymbols(sProd, symbols) == Tsymbols,
     Tprod == INJ(Tsymbols, Tsort),
     @rhs.type := Tprod,
-    TprodNoLayout == removeLayoutFromProdResult(Tprod),
-    symbolDefProductionOK(Kexpected, TprodNoLayout, attrs, symbolDef),
-    attributesOk(sProd, countProdResult(TprodNoLayout), attrs).
+    symbolDefProductionOK(Kexpected, removeLayoutFromProdResult(Tprod), attrs, symbolDef),
+    attributesOk(sProd, attrs).
   typeOfSdfProduction(s, Kexpected, SdfProductionWithCons(sortCons, rhs@Rhs(symbols), attrs)) = Tprod :- {Kactual sProd Tsymbols Tsort TprodNoLayout}
     kindOfSortCons(s, sortCons) == Kactual,
     try { Kactual == Kexpected } | error $[Sort of production is of kind [Kactual], but expected it to be of kind [Kexpected] due to the section the production is defined in]@sortCons,
@@ -87,7 +86,6 @@ rules
     new sProd, sProd -P-> s,
     typesOfSymbols(sProd, symbols) == Tsymbols,
     @rhs.type := Tprod,
-    TprodNoLayout == removeLayoutFromProdResult(Tprod),
-    sortConsProductionOK(Kexpected, TprodNoLayout, attrs, sortCons),
-    attributesOk(sProd, countProdResult(TprodNoLayout), attrs).
+    sortConsProductionOK(Kexpected, removeLayoutFromProdResult(Tprod), attrs, sortCons),
+    attributesOk(sProd, attrs).
   typeOfSdfProductions maps typeOfSdfProduction(*, *, list(*)) = list(*)

--- a/org.metaborg.meta.lang.template/trans/statix/section/syntax.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/section/syntax.stx
@@ -41,25 +41,25 @@ signature
 
 rules
 
-  grammarOK(s, Syntax(productions))                    :- productionsOK(s, KERNEL(), productions).
-  grammarOK(s, Lexical(productions))                   :- productionsOK(s, LEXICAL(), productions).
-  grammarOK(s, Contextfree(productions))               :- productionsOK(s, CONTEXTFREE(), productions).
-  grammarOK(s, Variables(productions))                 :- productionsOK(s, VAR(), productions).
-  grammarOK(s, LexVariables(productions))              :- productionsOK(s, VAR(), productions).
+  grammarOK(s, Syntax(productions))                    :- kernelProductionsOK(s, KERNEL(), productions).
+  grammarOK(s, Lexical(productions))                   :- kernelProductionsOK(s, LEXICAL(), productions).
+  grammarOK(s, Contextfree(productions))               :- kernelProductionsOK(s, CONTEXTFREE(), productions).
+  grammarOK(s, Variables(productions))                 :- kernelProductionsOK(s, VAR(), productions).
+  grammarOK(s, LexVariables(productions))              :- kernelProductionsOK(s, VAR(), productions).
   grammarOK(s, VariablesProductive(sdfProductions))    :- typeOfSdfProductions(s, VAR(), sdfProductions) == _.
   grammarOK(s, LexVariablesProductive(sdfProductions)) :- typeOfSdfProductions(s, VAR(), sdfProductions) == _.
   grammarOK(s, Kernel(sdfProductions))                 :- typeOfSdfProductions(s, KERNEL(), sdfProductions) == _.
   grammarOK(s, LexicalSyntax(sdfProductions))          :- typeOfSdfProductions(s, LEXICAL(), sdfProductions) == _.
   grammarOK(s, ContextFreeSyntax(generalProductions))  :- generalProductionsOK(s, CONTEXTFREE(), generalProductions).
 
-  productionOK: scope * SORT_KIND * Production
-  productionOK(s, Kexpected, Prod(symbols, symbol, _)) :- {Kactual sProd}
+  kernelProductionOK: scope * SORT_KIND * Production
+  kernelProductionOK(s, Kexpected, Prod(symbols, symbol, _)) :- {Kactual sProd}
     kindOfSymbol(s, symbol) == Kactual,
     try { Kactual == Kexpected } | error $[Sort of production is of kind [Kactual], but expected it to be of kind [Kexpected] due to the section the production is defined in]@symbol,
     new sProd, sProd -P-> s,
     typesOfSymbols(sProd, symbols) == _,
     typeOfSymbol(sProd, symbol) == _.
-  productionsOK maps productionOK(*, *, list(*))
+  kernelProductionsOK maps kernelProductionOK(*, *, list(*))
 
   generalProductionOK: scope * SORT_KIND * GeneralProduction
   generalProductionOK(s, Kexpected, GeneralProduction_SdfProduction(sdfProduction))           :-
@@ -76,13 +76,14 @@ rules
     new sProd, sProd -P-> s,
     typesOfSymbols(sProd, symbols) == Tsymbols,
     Tprod == INJ(Tsymbols, Tsort),
-    injectionProductionOK(Tprod, attrs, symbolDef),
+    symbolDefProductionOK(Kexpected, removeLayoutFromProdResult(Tprod), attrs, symbolDef),
     @rhs.type := Tprod.
-  typeOfSdfProduction(s, Kexpected, SdfProductionWithCons(sortCons, rhs@Rhs(symbols), _)) = Tprod :- {Kactual sProd Tsymbols Tsort}
+  typeOfSdfProduction(s, Kexpected, SdfProductionWithCons(sortCons, rhs@Rhs(symbols), attrs)) = Tprod :- {Kactual sProd Tsymbols Tsort}
     kindOfSortCons(s, sortCons) == Kactual,
     try { Kactual == Kexpected } | error $[Sort of production is of kind [Kactual], but expected it to be of kind [Kexpected] due to the section the production is defined in]@sortCons,
     declareSortCons(s, Tsymbols, sortCons) == Tprod,
     new sProd, sProd -P-> s,
     typesOfSymbols(sProd, symbols) == Tsymbols,
+    sortConsProductionOK(Kexpected, removeLayoutFromProdResult(Tprod), attrs, sortCons),
     @rhs.type := Tprod.
   typeOfSdfProductions maps typeOfSdfProduction(*, *, list(*)) = list(*)

--- a/org.metaborg.meta.lang.template/trans/statix/section/syntax.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/section/syntax.stx
@@ -76,14 +76,16 @@ rules
     new sProd, sProd -P-> s,
     typesOfSymbols(sProd, symbols) == Tsymbols,
     Tprod == INJ(Tsymbols, Tsort),
+    @rhs.type := Tprod,
     symbolDefProductionOK(Kexpected, removeLayoutFromProdResult(Tprod), attrs, symbolDef),
-    @rhs.type := Tprod.
+    attributesOk(sProd, 0, attrs). // TODO: pass number of non-terminals
   typeOfSdfProduction(s, Kexpected, SdfProductionWithCons(sortCons, rhs@Rhs(symbols), attrs)) = Tprod :- {Kactual sProd Tsymbols Tsort}
     kindOfSortCons(s, sortCons) == Kactual,
     try { Kactual == Kexpected } | error $[Sort of production is of kind [Kactual], but expected it to be of kind [Kexpected] due to the section the production is defined in]@sortCons,
     declareSortCons(s, Tsymbols, sortCons) == Tprod,
     new sProd, sProd -P-> s,
     typesOfSymbols(sProd, symbols) == Tsymbols,
+    @rhs.type := Tprod,
     sortConsProductionOK(Kexpected, removeLayoutFromProdResult(Tprod), attrs, sortCons),
-    @rhs.type := Tprod.
+    attributesOk(sProd, 0, attrs). // TODO: pass number of non-terminals
   typeOfSdfProductions maps typeOfSdfProduction(*, *, list(*)) = list(*)

--- a/org.metaborg.meta.lang.template/trans/statix/section/syntax.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/section/syntax.stx
@@ -41,42 +41,48 @@ signature
 
 rules
 
-  grammarOK(s, Syntax(productions))                    :- productionsOK(s, productions).
-  grammarOK(s, Lexical(productions))                   :- productionsOK(s, productions).
-  grammarOK(s, Contextfree(productions))               :- productionsOK(s, productions).
-  grammarOK(s, Variables(productions))                 :- productionsOK(s, productions).
-  grammarOK(s, LexVariables(productions))              :- productionsOK(s, productions).
-  grammarOK(s, VariablesProductive(sdfProductions))    :- typeOfSdfProductions(s, sdfProductions) == _.
-  grammarOK(s, LexVariablesProductive(sdfProductions)) :- typeOfSdfProductions(s, sdfProductions) == _.
-  grammarOK(s, Kernel(sdfProductions))                 :- typeOfSdfProductions(s, sdfProductions) == _.
-  grammarOK(s, LexicalSyntax(sdfProductions))          :- typeOfSdfProductions(s, sdfProductions) == _.
-  grammarOK(s, ContextFreeSyntax(generalProductions))  :- generalProductionsOK(s, generalProductions).
+  grammarOK(s, Syntax(productions))                    :- productionsOK(s, KERNEL(), productions).
+  grammarOK(s, Lexical(productions))                   :- productionsOK(s, LEXICAL(), productions).
+  grammarOK(s, Contextfree(productions))               :- productionsOK(s, CONTEXTFREE(), productions).
+  grammarOK(s, Variables(productions))                 :- productionsOK(s, VAR(), productions).
+  grammarOK(s, LexVariables(productions))              :- productionsOK(s, VAR(), productions).
+  grammarOK(s, VariablesProductive(sdfProductions))    :- typeOfSdfProductions(s, VAR(), sdfProductions) == _.
+  grammarOK(s, LexVariablesProductive(sdfProductions)) :- typeOfSdfProductions(s, VAR(), sdfProductions) == _.
+  grammarOK(s, Kernel(sdfProductions))                 :- typeOfSdfProductions(s, KERNEL(), sdfProductions) == _.
+  grammarOK(s, LexicalSyntax(sdfProductions))          :- typeOfSdfProductions(s, LEXICAL(), sdfProductions) == _.
+  grammarOK(s, ContextFreeSyntax(generalProductions))  :- generalProductionsOK(s, CONTEXTFREE(), generalProductions).
 
-  productionOK: scope * Production
-  productionOK(s, Prod(symbols, symbol, _)) :- {sProd}
+  productionOK: scope * SORT_KIND * Production
+  productionOK(s, Kexpected, Prod(symbols, symbol, _)) :- {Kactual sProd}
+    kindOfSymbol(s, symbol) == Kactual,
+    try { Kactual == Kexpected } | error $[Sort of production is of kind [Kactual], but expected it to be of kind [Kexpected] due to the section the production is defined in]@symbol,
     new sProd, sProd -P-> s,
     typesOfSymbols(sProd, symbols) == _,
     typeOfSymbol(sProd, symbol) == _.
-  productionsOK maps productionOK(*, list(*))
+  productionsOK maps productionOK(*, *, list(*))
 
-  generalProductionOK: scope * GeneralProduction
-  generalProductionOK(s, GeneralProduction_SdfProduction(sdfProduction))           :-
-    typeOfSdfProduction(s, sdfProduction) == _.
-  generalProductionOK(s, GeneralProduction_TemplateProduction(templateProduction)) :-
-    typeOfTemplateProduction(s, templateProduction) == _.
-  generalProductionsOK maps generalProductionOK(*, list(*))
+  generalProductionOK: scope * SORT_KIND * GeneralProduction
+  generalProductionOK(s, Kexpected, GeneralProduction_SdfProduction(sdfProduction))           :-
+    typeOfSdfProduction(s, Kexpected, sdfProduction) == _.
+  generalProductionOK(s, Kexpected, GeneralProduction_TemplateProduction(templateProduction)) :-
+    typeOfTemplateProduction(s, Kexpected, templateProduction) == _.
+  generalProductionsOK maps generalProductionOK(*, *, list(*))
 
-  typeOfSdfProduction: scope * SdfProduction -> TYPE
-  typeOfSdfProduction(s, SdfProduction(symbolDef, rhs@Rhs(symbols), attrs)) = Tprod :- {sProd Tsymbols Tsort}
+  typeOfSdfProduction: scope * SORT_KIND * SdfProduction -> TYPE
+  typeOfSdfProduction(s, Kexpected, SdfProduction(symbolDef, rhs@Rhs(symbols), attrs)) = Tprod :- {Kactual sProd Tsymbols Tsort}
+    kindOfSymbolDef(s, symbolDef) == Kactual,
+    try { Kactual == Kexpected } | error $[Sort of production is of kind [Kactual], but expected it to be of kind [Kexpected] due to the section the production is defined in]@symbolDef,
     typeOfSymbolDef(s, symbolDef) == Tsort,
     new sProd, sProd -P-> s,
     typesOfSymbols(sProd, symbols) == Tsymbols,
     Tprod == INJ(Tsymbols, Tsort),
     injectionProductionOK(Tprod, attrs, symbolDef),
     @rhs.type := Tprod.
-  typeOfSdfProduction(s, SdfProductionWithCons(sortCons, rhs@Rhs(symbols), _)) = Tprod :- {sProd Tsymbols Tsort}
+  typeOfSdfProduction(s, Kexpected, SdfProductionWithCons(sortCons, rhs@Rhs(symbols), _)) = Tprod :- {Kactual sProd Tsymbols Tsort}
+    kindOfSortCons(s, sortCons) == Kactual,
+    try { Kactual == Kexpected } | error $[Sort of production is of kind [Kactual], but expected it to be of kind [Kexpected] due to the section the production is defined in]@sortCons,
     declareSortCons(s, Tsymbols, sortCons) == Tprod,
     new sProd, sProd -P-> s,
     typesOfSymbols(sProd, symbols) == Tsymbols,
     @rhs.type := Tprod.
-  typeOfSdfProductions maps typeOfSdfProduction(*, list(*)) = list(*)
+  typeOfSdfProductions maps typeOfSdfProduction(*, *, list(*)) = list(*)

--- a/org.metaborg.meta.lang.template/trans/statix/section/syntax.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/section/syntax.stx
@@ -69,7 +69,7 @@ rules
   generalProductionsOK maps generalProductionOK(*, *, list(*))
 
   typeOfSdfProduction: scope * SORT_KIND * SdfProduction -> TYPE
-  typeOfSdfProduction(s, Kexpected, SdfProduction(symbolDef, rhs@Rhs(symbols), attrs)) = Tprod :- {Kactual sProd Tsymbols Tsort}
+  typeOfSdfProduction(s, Kexpected, SdfProduction(symbolDef, rhs@Rhs(symbols), attrs)) = Tprod :- {Kactual sProd Tsymbols Tsort TprodNoLayout}
     kindOfSymbolDef(s, symbolDef) == Kactual,
     try { Kactual == Kexpected } | error $[Sort of production is of kind [Kactual], but expected it to be of kind [Kexpected] due to the section the production is defined in]@symbolDef,
     typeOfSymbolDef(s, symbolDef) == Tsort,
@@ -77,15 +77,17 @@ rules
     typesOfSymbols(sProd, symbols) == Tsymbols,
     Tprod == INJ(Tsymbols, Tsort),
     @rhs.type := Tprod,
-    symbolDefProductionOK(Kexpected, removeLayoutFromProdResult(Tprod), attrs, symbolDef),
-    attributesOk(sProd, 0, attrs). // TODO: pass number of non-terminals
-  typeOfSdfProduction(s, Kexpected, SdfProductionWithCons(sortCons, rhs@Rhs(symbols), attrs)) = Tprod :- {Kactual sProd Tsymbols Tsort}
+    TprodNoLayout == removeLayoutFromProdResult(Tprod),
+    symbolDefProductionOK(Kexpected, TprodNoLayout, attrs, symbolDef),
+    attributesOk(sProd, countProdResult(TprodNoLayout), attrs).
+  typeOfSdfProduction(s, Kexpected, SdfProductionWithCons(sortCons, rhs@Rhs(symbols), attrs)) = Tprod :- {Kactual sProd Tsymbols Tsort TprodNoLayout}
     kindOfSortCons(s, sortCons) == Kactual,
     try { Kactual == Kexpected } | error $[Sort of production is of kind [Kactual], but expected it to be of kind [Kexpected] due to the section the production is defined in]@sortCons,
     declareSortCons(s, Tsymbols, sortCons) == Tprod,
     new sProd, sProd -P-> s,
     typesOfSymbols(sProd, symbols) == Tsymbols,
     @rhs.type := Tprod,
-    sortConsProductionOK(Kexpected, removeLayoutFromProdResult(Tprod), attrs, sortCons),
-    attributesOk(sProd, 0, attrs). // TODO: pass number of non-terminals
+    TprodNoLayout == removeLayoutFromProdResult(Tprod),
+    sortConsProductionOK(Kexpected, TprodNoLayout, attrs, sortCons),
+    attributesOk(sProd, countProdResult(TprodNoLayout), attrs).
   typeOfSdfProductions maps typeOfSdfProduction(*, *, list(*)) = list(*)

--- a/org.metaborg.meta.lang.template/trans/statix/section/template.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/section/template.stx
@@ -43,22 +43,27 @@ signature // Section
 
 rules
 
-  sectionOK(s, TemplateSection(templateProductions)) :- typeOfTemplateProductions(s, templateProductions) == _.
+  sectionOK(s, TemplateSection(templateProductions)) :-
+    typeOfTemplateProductions(s, CONTEXTFREE(), templateProductions) == _.
 
-  typeOfTemplateProduction: scope * TemplateProduction -> TYPE
-  typeOfTemplateProduction(s, TemplateProduction(symbolDef, template, attrs)) = Tprod :- {sProd Tsymbols Tsort}
+  typeOfTemplateProduction: scope * SORT_KIND * TemplateProduction -> TYPE
+  typeOfTemplateProduction(s, Kexpected, TemplateProduction(symbolDef, template, attrs)) = Tprod :- {Kactual sProd Tsymbols Tsort}
+    kindOfSymbolDef(s, symbolDef) == Kactual,
+    try { Kactual == Kexpected } | error $[Sort of production is of kind [Kactual], but expected it to be of kind [Kexpected] due to the section the production is defined in]@symbolDef,
     typeOfSymbolDef(s, symbolDef) == Tsort,
     new sProd, sProd -P-> s,
     typeOfTemplate(sProd, template) == Tsymbols,
     Tprod == INJ(Tsymbols, Tsort),
     injectionProductionOK(Tprod, attrs, symbolDef),
     @template.type := Tprod.
-  typeOfTemplateProduction(s, TemplateProductionWithCons(sortCons, template, _)) = Tprod :- {sProd Tsymbols Tsort}
+  typeOfTemplateProduction(s, Kexpected, TemplateProductionWithCons(sortCons, template, _)) = Tprod :- {Kactual sProd Tsymbols Tsort}
+    kindOfSortCons(s, sortCons) == Kactual,
+    try { Kactual == Kexpected } | error $[Sort of production is of kind [Kactual], but expected it to be of kind [Kexpected] due to the section the production is defined in]@sortCons,
     declareSortCons(s, Tsymbols, sortCons) == Tprod,
     new sProd, sProd -P-> s,
     typeOfTemplate(sProd, template) == Tsymbols,
     @template.type := Tprod.
-  typeOfTemplateProductions maps typeOfTemplateProduction(*, list(*)) = list(*)
+  typeOfTemplateProductions maps typeOfTemplateProduction(*, *, list(*)) = list(*)
 
   typeOfTemplate: scope * Template -> list(TYPE)
   typeOfTemplate(s, Template(lines))            = flattenTypes(typeOfTemplateLines(s, lines)).     /* Flatten nested list */

--- a/org.metaborg.meta.lang.template/trans/statix/section/template.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/section/template.stx
@@ -54,16 +54,18 @@ rules
     new sProd, sProd -P-> s,
     typeOfTemplate(sProd, template) == Tsymbols,
     Tprod == INJ(Tsymbols, Tsort),
+    @template.type := Tprod,
     symbolDefProductionOK(Kexpected, removeLayoutFromProdResult(Tprod), attrs, symbolDef),
-    @template.type := Tprod.
+    attributesOk(sProd, 0, attrs). // TODO: pass number of non-terminals
   typeOfTemplateProduction(s, Kexpected, TemplateProductionWithCons(sortCons, template, attrs)) = Tprod :- {Kactual sProd Tsymbols Tsort}
     kindOfSortCons(s, sortCons) == Kactual,
     try { Kactual == Kexpected } | error $[Sort of production is of kind [Kactual], but expected it to be of kind [Kexpected] due to the section the production is defined in]@sortCons,
     declareSortCons(s, Tsymbols, sortCons) == Tprod,
     new sProd, sProd -P-> s,
     typeOfTemplate(sProd, template) == Tsymbols,
+    @template.type := Tprod,
     sortConsProductionOK(Kexpected, removeLayoutFromProdResult(Tprod), attrs, sortCons),
-    @template.type := Tprod.
+    attributesOk(sProd, 0, attrs). // TODO: pass number of non-terminals
   typeOfTemplateProductions maps typeOfTemplateProduction(*, *, list(*)) = list(*)
 
   typeOfTemplate: scope * Template -> list(TYPE)

--- a/org.metaborg.meta.lang.template/trans/statix/section/template.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/section/template.stx
@@ -47,7 +47,7 @@ rules
     typeOfTemplateProductions(s, CONTEXTFREE(), templateProductions) == _.
 
   typeOfTemplateProduction: scope * SORT_KIND * TemplateProduction -> TYPE
-  typeOfTemplateProduction(s, Kexpected, TemplateProduction(symbolDef, template, attrs)) = Tprod :- {Kactual sProd Tsymbols Tsort TprodNoLayout}
+  typeOfTemplateProduction(s, Kexpected, TemplateProduction(symbolDef, template, attrs)) = Tprod :- {Kactual sProd Tsymbols Tsort}
     kindOfSymbolDef(s, symbolDef) == Kactual,
     try { Kactual == Kexpected } | error $[Sort of production is of kind [Kactual], but expected it to be of kind [Kexpected] due to the section the production is defined in]@symbolDef,
     typeOfSymbolDef(s, symbolDef) == Tsort,
@@ -55,19 +55,17 @@ rules
     typeOfTemplate(sProd, template) == Tsymbols,
     Tprod == INJ(Tsymbols, Tsort),
     @template.type := Tprod,
-    TprodNoLayout == removeLayoutFromProdResult(Tprod),
-    symbolDefProductionOK(Kexpected, TprodNoLayout, attrs, symbolDef),
-    attributesOk(sProd, countProdResult(TprodNoLayout), attrs).
-  typeOfTemplateProduction(s, Kexpected, TemplateProductionWithCons(sortCons, template, attrs)) = Tprod :- {Kactual sProd Tsymbols Tsort TprodNoLayout}
+    symbolDefProductionOK(Kexpected, removeLayoutFromProdResult(Tprod), attrs, symbolDef),
+    attributesOk(sProd, attrs).
+  typeOfTemplateProduction(s, Kexpected, TemplateProductionWithCons(sortCons, template, attrs)) = Tprod :- {Kactual sProd Tsymbols Tsort}
     kindOfSortCons(s, sortCons) == Kactual,
     try { Kactual == Kexpected } | error $[Sort of production is of kind [Kactual], but expected it to be of kind [Kexpected] due to the section the production is defined in]@sortCons,
     declareSortCons(s, Tsymbols, sortCons) == Tprod,
     new sProd, sProd -P-> s,
     typeOfTemplate(sProd, template) == Tsymbols,
     @template.type := Tprod,
-    TprodNoLayout == removeLayoutFromProdResult(Tprod),
-    sortConsProductionOK(Kexpected, TprodNoLayout, attrs, sortCons),
-    attributesOk(sProd, countProdResult(TprodNoLayout), attrs).
+    sortConsProductionOK(Kexpected, removeLayoutFromProdResult(Tprod), attrs, sortCons),
+    attributesOk(sProd, attrs).
   typeOfTemplateProductions maps typeOfTemplateProduction(*, *, list(*)) = list(*)
 
   typeOfTemplate: scope * Template -> list(TYPE)

--- a/org.metaborg.meta.lang.template/trans/statix/section/template.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/section/template.stx
@@ -47,7 +47,7 @@ rules
     typeOfTemplateProductions(s, CONTEXTFREE(), templateProductions) == _.
 
   typeOfTemplateProduction: scope * SORT_KIND * TemplateProduction -> TYPE
-  typeOfTemplateProduction(s, Kexpected, TemplateProduction(symbolDef, template, attrs)) = Tprod :- {Kactual sProd Tsymbols Tsort}
+  typeOfTemplateProduction(s, Kexpected, TemplateProduction(symbolDef, template, attrs)) = Tprod :- {Kactual sProd Tsymbols Tsort TprodNoLayout}
     kindOfSymbolDef(s, symbolDef) == Kactual,
     try { Kactual == Kexpected } | error $[Sort of production is of kind [Kactual], but expected it to be of kind [Kexpected] due to the section the production is defined in]@symbolDef,
     typeOfSymbolDef(s, symbolDef) == Tsort,
@@ -55,17 +55,19 @@ rules
     typeOfTemplate(sProd, template) == Tsymbols,
     Tprod == INJ(Tsymbols, Tsort),
     @template.type := Tprod,
-    symbolDefProductionOK(Kexpected, removeLayoutFromProdResult(Tprod), attrs, symbolDef),
-    attributesOk(sProd, 0, attrs). // TODO: pass number of non-terminals
-  typeOfTemplateProduction(s, Kexpected, TemplateProductionWithCons(sortCons, template, attrs)) = Tprod :- {Kactual sProd Tsymbols Tsort}
+    TprodNoLayout == removeLayoutFromProdResult(Tprod),
+    symbolDefProductionOK(Kexpected, TprodNoLayout, attrs, symbolDef),
+    attributesOk(sProd, countProdResult(TprodNoLayout), attrs).
+  typeOfTemplateProduction(s, Kexpected, TemplateProductionWithCons(sortCons, template, attrs)) = Tprod :- {Kactual sProd Tsymbols Tsort TprodNoLayout}
     kindOfSortCons(s, sortCons) == Kactual,
     try { Kactual == Kexpected } | error $[Sort of production is of kind [Kactual], but expected it to be of kind [Kexpected] due to the section the production is defined in]@sortCons,
     declareSortCons(s, Tsymbols, sortCons) == Tprod,
     new sProd, sProd -P-> s,
     typeOfTemplate(sProd, template) == Tsymbols,
     @template.type := Tprod,
-    sortConsProductionOK(Kexpected, removeLayoutFromProdResult(Tprod), attrs, sortCons),
-    attributesOk(sProd, 0, attrs). // TODO: pass number of non-terminals
+    TprodNoLayout == removeLayoutFromProdResult(Tprod),
+    sortConsProductionOK(Kexpected, TprodNoLayout, attrs, sortCons),
+    attributesOk(sProd, countProdResult(TprodNoLayout), attrs).
   typeOfTemplateProductions maps typeOfTemplateProduction(*, *, list(*)) = list(*)
 
   typeOfTemplate: scope * Template -> list(TYPE)

--- a/org.metaborg.meta.lang.template/trans/statix/section/template.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/section/template.stx
@@ -54,14 +54,15 @@ rules
     new sProd, sProd -P-> s,
     typeOfTemplate(sProd, template) == Tsymbols,
     Tprod == INJ(Tsymbols, Tsort),
-    injectionProductionOK(Tprod, attrs, symbolDef),
+    symbolDefProductionOK(Kexpected, removeLayoutFromProdResult(Tprod), attrs, symbolDef),
     @template.type := Tprod.
-  typeOfTemplateProduction(s, Kexpected, TemplateProductionWithCons(sortCons, template, _)) = Tprod :- {Kactual sProd Tsymbols Tsort}
+  typeOfTemplateProduction(s, Kexpected, TemplateProductionWithCons(sortCons, template, attrs)) = Tprod :- {Kactual sProd Tsymbols Tsort}
     kindOfSortCons(s, sortCons) == Kactual,
     try { Kactual == Kexpected } | error $[Sort of production is of kind [Kactual], but expected it to be of kind [Kexpected] due to the section the production is defined in]@sortCons,
     declareSortCons(s, Tsymbols, sortCons) == Tprod,
     new sProd, sProd -P-> s,
     typeOfTemplate(sProd, template) == Tsymbols,
+    sortConsProductionOK(Kexpected, removeLayoutFromProdResult(Tprod), attrs, sortCons),
     @template.type := Tprod.
   typeOfTemplateProductions maps typeOfTemplateProduction(*, *, list(*)) = list(*)
 
@@ -90,6 +91,9 @@ rules
   maybeTypeOfTemplatePart: scope * TemplatePart -> list(TYPE)
   maybeTypeOfTemplatePart(s, Angled(placeholder))  = [typeOfPlaceholder(s, placeholder)].
   maybeTypeOfTemplatePart(s, Squared(placeholder)) = [typeOfPlaceholder(s, placeholder)].
+  maybeTypeOfTemplatePart(s, String(_))            = [TERMINAL()].
+  maybeTypeOfTemplatePart(s, Escape(_))            = [TERMINAL()].
+  maybeTypeOfTemplatePart(s, Layout(_))            = [LAYOUT()].
   maybeTypeOfTemplatePart(s, _)                    = [].
 
   typeOfPlaceholder: scope * Placeholder -> TYPE

--- a/org.metaborg.meta.lang.template/trans/statix/sort.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/sort.stx
@@ -9,9 +9,10 @@ imports
 signature
 
   sorts SORT_KIND constructors
-    CONTEXTFREE :  SORT_KIND
-    LEXICAL     :  SORT_KIND
-    VAR         :  SORT_KIND
+    CONTEXTFREE : SORT_KIND
+    LEXICAL     : SORT_KIND
+    VAR         : SORT_KIND
+    KERNEL      : SORT_KIND
 
   relations
     kindOfSort : occurrence -> SORT_KIND
@@ -39,14 +40,14 @@ rules
   resolveTypeOfSorts(name, [], MAYBE_EMPTY()) = _.
 
   kindOfSort : scope * string -> SORT_KIND
-  kindOfSort(s, name) = Tsort :- {paths}
+  kindOfSort(s, name) = K :- {paths}
     kindOfSort of Sort{name} in s |-> paths,
-    resolveKindOfSorts(name, paths, NON_EMPTY()) == Tsort,
-    @name.type := Tsort.
+    resolveKindOfSorts(name, paths, NON_EMPTY()) == K,
+    @name.kind := K.
 
   resolveKindOfSorts : string * list((path * (occurrence * SORT_KIND))) * EMPTINESS -> SORT_KIND
-  resolveKindOfSorts(name, [(_, (Sort{name'}, Tsort))|paths], _) = Tsort :-
+  resolveKindOfSorts(name, [(_, (Sort{name'}, K))|paths], _) = K :-
     @name.ref += name',
-    resolveKindOfSorts(name, paths, MAYBE_EMPTY()) == Tsort.
+    resolveKindOfSorts(name, paths, MAYBE_EMPTY()) == K.
   resolveKindOfSorts(name, [], NON_EMPTY())   = _ :- false | error $[Sort [name] is not defined]@name.
   resolveKindOfSorts(name, [], MAYBE_EMPTY()) = _.

--- a/org.metaborg.meta.lang.template/trans/statix/sort_cons.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/sort_cons.stx
@@ -34,12 +34,23 @@ rules
     typeOfSymbolDef(s, symbolDef) == Tsort,
     declareConstructor(s, Tsymbols, Tsort, constructorName) == Tprod.
 
+  kindOfSortCons: scope * SortCons -> SORT_KIND
+  kindOfSortCons(s, SortCons(symbolDef, Constructor(_))) = K :-
+    kindOfSymbolDef(s, symbolDef) == K.
+
   typeOfSymbolDef: scope * SymbolDef -> TYPE
   typeOfSymbolDef(s, SortDef(name))            = Tsort :- typeOfSort(s, name)           == Tsort.
   typeOfSymbolDef(s, SymbolDefCf(symbolDef))   = T     :- typeOfSymbolDef(s, symbolDef) == T.
   typeOfSymbolDef(s, SymbolDefLex(symbolDef))  = T     :- typeOfSymbolDef(s, symbolDef) == T.
   typeOfSymbolDef(s, SymbolDefVar(symbolDef))  = T     :- typeOfSymbolDef(s, symbolDef) == T.
   typeOfSymbolDef(s, SymbolDef_Symbol(symbol)) = T     :- typeOfSymbol(s, symbol)       == T.
+
+  kindOfSymbolDef: scope * SymbolDef -> SORT_KIND
+  kindOfSymbolDef(s, SortDef(name))   = K :- kindOfSort(s, name) == K.
+  kindOfSymbolDef(s, SymbolDefCf(_))  = CONTEXTFREE().
+  kindOfSymbolDef(s, SymbolDefLex(_)) = LEXICAL().
+  kindOfSymbolDef(s, SymbolDefVar(_)) = VAR().
+  kindOfSymbolDef(s, SymbolDef_Symbol(symbol)) = K :- kindOfSymbol(s, symbol) == K.
 
   typeOfSortConsRef: scope * SortConsRef -> TYPE
   typeOfSortConsRef(s, SortConsRef(symbol, Constructor(constructorName))) = Tprod :- {Tsort}

--- a/org.metaborg.meta.lang.template/trans/statix/sort_cons.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/sort_cons.stx
@@ -47,9 +47,9 @@ rules
 
   kindOfSymbolDef: scope * SymbolDef -> SORT_KIND
   kindOfSymbolDef(s, SortDef(name))   = K :- kindOfSort(s, name) == K.
-  kindOfSymbolDef(s, SymbolDefCf(_))  = CONTEXTFREE().
-  kindOfSymbolDef(s, SymbolDefLex(_)) = LEXICAL().
-  kindOfSymbolDef(s, SymbolDefVar(_)) = VAR().
+  kindOfSymbolDef(s, SymbolDefCf(_))  = KERNEL().
+  kindOfSymbolDef(s, SymbolDefLex(_)) = KERNEL().
+  kindOfSymbolDef(s, SymbolDefVar(_)) = KERNEL().
   kindOfSymbolDef(s, SymbolDef_Symbol(symbol)) = K :- kindOfSymbol(s, symbol) == K.
 
   typeOfSortConsRef: scope * SortConsRef -> TYPE

--- a/org.metaborg.meta.lang.template/trans/statix/symbol.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/symbol.stx
@@ -69,7 +69,7 @@ rules
     typeOfSymbol(s, symbol1) == T1,
     typeOfSymbol(s, symbol2) == T2.
 
-  typeOfSymbol(s, Layout())     = TERMINAL().
+  typeOfSymbol(s, Layout())     = LAYOUT().
   typeOfSymbol(s, CharClass(_)) = TERMINAL().
   typeOfSymbol(s, Lit(_))       = TERMINAL().
   typeOfSymbol(s, CiLit(_))     = TERMINAL().

--- a/org.metaborg.meta.lang.template/trans/statix/symbol.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/symbol.stx
@@ -75,3 +75,48 @@ rules
   typeOfSymbol(s, CiLit(_))     = TERMINAL().
 
   typesOfSymbols maps typeOfSymbol(*, list(*)) = list(*)
+
+rules
+
+  kindOfSymbol: scope * Symbol -> SORT_KIND
+
+  kindOfSymbol(s, sy@Sort(name)) = K :-
+    kindOfSort(s, name) == K,
+    @sy.kind := K.
+  kindOfSymbol(s, sy@ParameterizedSort(name, symbols)) = K :-
+    kindOfSort(s, name) == K,
+    kindsOfSymbols(s, symbols) == _,
+    @sy.kind := K.
+
+  kindOfSymbol(s, Cf(symbol)) = CONTEXTFREE() :-
+    kindOfSymbol(s, symbol) == _. // TODO: check kind?
+  kindOfSymbol(s, Lex(symbol)) = LEXICAL() :-
+    kindOfSymbol(s, symbol) == _. // TODO: check kind?
+  kindOfSymbol(s, Varsym(symbol)) = VAR() :-
+    kindOfSymbol(s, symbol) == _. // TODO: check kind?
+  kindOfSymbol(s, Label(label, symbol)) = K :-
+    labelOK(s, label),
+    kindOfSymbol(s, symbol) == K.
+  kindOfSymbol(s, Sequence(symbol, symbols)) = K :- // TODO: what is the kind of a sequence?
+    kindOfSymbol(s, symbol) == K,
+    kindsOfSymbols(s, symbols) == _. // TODO: check kinds?
+  kindOfSymbol(s, Opt(symbol)) = K :- // TODO: what is the kind of an option?
+    kindOfSymbol(s, symbol) == K.
+  kindOfSymbol(s, Iter(symbol)) = K :- // TODO: what is the kind of an iter?
+    kindOfSymbol(s, symbol) == K.
+  kindOfSymbol(s, IterStar(symbol)) = K :- // TODO: what is the kind of an iterstar?
+    kindOfSymbol(s, symbol) == K.
+  kindOfSymbol(s, IterSep(symbol, _)) = K :- // TODO: what is the kind of an itersep?
+    kindOfSymbol(s, symbol) == K.
+  kindOfSymbol(s, IterStarSep(symbol, _)) = K :- // TODO: what is the kind of an iterstarsep?
+    kindOfSymbol(s, symbol) == K.
+  kindOfSymbol(s, Alt(symbol1, symbol2)) = K :- // TODO: what is the kind of an alt?
+    kindOfSymbol(s, symbol1) == K,
+    kindOfSymbol(s, symbol2) == _. // TODO: check kinds?
+
+  kindOfSymbol(s, Layout())     = LEXICAL().
+  kindOfSymbol(s, CharClass(_)) = LEXICAL().
+  kindOfSymbol(s, Lit(_))       = LEXICAL().
+  kindOfSymbol(s, CiLit(_))     = LEXICAL().
+
+  kindsOfSymbols maps kindOfSymbol(*, list(*)) = list(*)

--- a/org.metaborg.meta.lang.template/trans/statix/symbol.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/symbol.stx
@@ -88,11 +88,11 @@ rules
     kindsOfSymbols(s, symbols) == _,
     @sy.kind := K.
 
-  kindOfSymbol(s, Cf(symbol)) = CONTEXTFREE() :-
+  kindOfSymbol(s, Cf(symbol)) = KERNEL() :-
     kindOfSymbol(s, symbol) == _. // TODO: check kind?
-  kindOfSymbol(s, Lex(symbol)) = LEXICAL() :-
+  kindOfSymbol(s, Lex(symbol)) = KERNEL() :-
     kindOfSymbol(s, symbol) == _. // TODO: check kind?
-  kindOfSymbol(s, Varsym(symbol)) = VAR() :-
+  kindOfSymbol(s, Varsym(symbol)) = KERNEL() :-
     kindOfSymbol(s, symbol) == _. // TODO: check kind?
   kindOfSymbol(s, Label(label, symbol)) = K :-
     labelOK(s, label),

--- a/org.metaborg.meta.lang.template/trans/statix/type.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/type.stx
@@ -9,6 +9,7 @@ signature
     ITER     : TYPE              -> TYPE
     ALT      : TYPE * TYPE       -> TYPE
     TERMINAL :                      TYPE
+    LAYOUT   :                      TYPE
     PROD     : list(TYPE) * TYPE -> TYPE
     INJ      : list(TYPE) * TYPE -> TYPE
     MOD      : scope             -> TYPE
@@ -35,3 +36,13 @@ rules
   flattenTypes : list(list(TYPE)) -> list(TYPE)
   flattenTypes([ts|tts]) = appendTypes(ts, flattenTypes(tts)).
   flattenTypes([      ]) = [].
+
+  removeLayout : list(TYPE) -> list(TYPE)
+  removeLayout([LAYOUT()|ts]) = removeLayout(ts).
+  removeLayout([t|ts])        = [t|removeLayout(ts)].
+  removeLayout([ ])           = [].
+
+  removeLayoutFromProdResult : TYPE -> TYPE
+  removeLayoutFromProdResult(PROD(ts, t)) = PROD(removeLayout(ts), t).
+  removeLayoutFromProdResult(INJ(ts, t))  = INJ(removeLayout(ts), t).
+  removeLayoutFromProdResult(t)           = t.

--- a/org.metaborg.meta.lang.template/trans/statix/type.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/type.stx
@@ -46,14 +46,3 @@ rules
   removeLayoutFromProdResult(PROD(ts, t)) = PROD(removeLayout(ts), t).
   removeLayoutFromProdResult(INJ(ts, t))  = INJ(removeLayout(ts), t).
   removeLayoutFromProdResult(t)           = t.
-
-  countProdResult : TYPE -> int
-  countProdResult(PROD(ts, _)) = countTypeList(ts).
-  countProdResult(INJ(ts, _))  = countTypeList(ts).
-  countProdResult(_)           = 0.
-
-  countTypeList : list(TYPE) -> int
-  countTypeList([_|ts]) = c :- {cts}
-    cts == countTypeList(ts),
-    c #= 1 + cts.
-  countTypeList([]) = 0.

--- a/org.metaborg.meta.lang.template/trans/statix/type.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/type.stx
@@ -31,18 +31,29 @@ rules
 
   appendTypes : list(TYPE) * list(TYPE) -> list(TYPE)
   appendTypes([t|ts], types) = [t|appendTypes(ts, types)].
-  appendTypes([    ], types) = types.
+  appendTypes([], types)     = types.
 
   flattenTypes : list(list(TYPE)) -> list(TYPE)
   flattenTypes([ts|tts]) = appendTypes(ts, flattenTypes(tts)).
-  flattenTypes([      ]) = [].
+  flattenTypes([])       = [].
 
   removeLayout : list(TYPE) -> list(TYPE)
   removeLayout([LAYOUT()|ts]) = removeLayout(ts).
   removeLayout([t|ts])        = [t|removeLayout(ts)].
-  removeLayout([ ])           = [].
+  removeLayout([])            = [].
 
   removeLayoutFromProdResult : TYPE -> TYPE
   removeLayoutFromProdResult(PROD(ts, t)) = PROD(removeLayout(ts), t).
   removeLayoutFromProdResult(INJ(ts, t))  = INJ(removeLayout(ts), t).
   removeLayoutFromProdResult(t)           = t.
+
+  countProdResult : TYPE -> int
+  countProdResult(PROD(ts, _)) = countTypeList(ts).
+  countProdResult(INJ(ts, _))  = countTypeList(ts).
+  countProdResult(_)           = 0.
+
+  countTypeList : list(TYPE) -> int
+  countTypeList([_|ts]) = c :- {cts}
+    cts == countTypeList(ts),
+    c #= 1 + cts.
+  countTypeList([]) = 0.

--- a/org.metaborg.meta.lang.template/trans/statix/util.stx
+++ b/org.metaborg.meta.lang.template/trans/statix/util.stx
@@ -21,3 +21,7 @@ rules
   bOr: BOOL  * BOOL    -> BOOL
   bOr(FALSE(), FALSE()) = FALSE().
   bOr(_      , _      ) = TRUE().
+
+  bNot: BOOL -> BOOL
+  bNot(FALSE()) = TRUE().
+  bNot(TRUE())  = FALSE().

--- a/org.metaborg.sdf2parenthesize/src/main/java/org/metaborg/sdf2parenthesize/parenthesizer/Parenthesizer.java
+++ b/org.metaborg.sdf2parenthesize/src/main/java/org/metaborg/sdf2parenthesize/parenthesizer/Parenthesizer.java
@@ -50,9 +50,7 @@ public class Parenthesizer {
         moduleName = "pp/" + moduleName + "-parenthesize";
         final String rule_name = name + "Parenthesize";
         NormGrammar grammar = table.normalizedGrammar();
-
-        // FIXME import all subfolders
-
+        
         List<IStrategoTerm> importsList = Lists.newArrayList();
         if(stratego2) {
             importsList.add(importModule("strategolib"));
@@ -60,20 +58,12 @@ public class Parenthesizer {
             importsList.add(importModule("libstratego-lib"));
         }
 
-        Set<String> paths = Sets.newHashSet();
-        for(File f : grammar.getFilesRead()) {
-            String path = f.getParent();
-            if(path.split("/normalized/").length == 2) {
-                String subfolder = path.split("/normalized/")[1];
-                if(paths.contains(subfolder)) {
-                    continue;
-                }
-                paths.add(subfolder);
-                importsList.add(importModuleWildCard("signatures/" + subfolder));
-            }
+        for(String inputModuleName : grammar.getModulesRead()) {
+            inputModuleName = inputModuleName
+                .replaceFirst("^normalized/", "")
+                .replaceFirst("-norm$", "");
+            importsList.add(importModule("signatures/" + inputModuleName + "-sig"));
         }
-
-        importsList.add(importModuleWildCard("signatures"));
 
         // Imports
         IStrategoTerm imports = tf.makeAppl(tf.makeConstructor("Imports", 1), tf.makeList(importsList));

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/NormGrammar.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/grammar/NormGrammar.java
@@ -15,8 +15,8 @@ public class NormGrammar implements INormGrammar, Serializable {
 
     private static final long serialVersionUID = -13739894962185282L;
 
-    // all files used in this grammar
-    private final Set<File> filesRead;
+    // all module names used in this grammar
+    private final Set<String> modulesRead;
 
     // factory to create all symbols in the grammar
     private final GrammarFactory gf;
@@ -79,7 +79,7 @@ public class NormGrammar implements INormGrammar, Serializable {
     private final SetMultimap<ISymbol, ISymbol> rightDerivable;
 
     public NormGrammar() {
-        this.filesRead = Sets.newHashSet();
+        this.modulesRead = Sets.newHashSet();
         this.gf = new GrammarFactory();
         this.uniqueProductionMapping = Maps.newLinkedHashMap();
         this.sortConsProductionMapping = Maps.newHashMap();
@@ -159,8 +159,8 @@ public class NormGrammar implements INormGrammar, Serializable {
         return priorities;
     }
 
-    public Set<File> getFilesRead() {
-        return filesRead;
+    public Set<String> getModulesRead() {
+        return modulesRead;
     }
 
     public Set<ISymbol> getSymbols() {
@@ -303,7 +303,6 @@ public class NormGrammar implements INormGrammar, Serializable {
         this.symbolProductionsMapping.clear();
         this.transitivePriorities.clear();
         this.transitivePriorityArgs.clear();
-        this.filesRead.clear();
     }
 
     public SetMultimap<ISymbol, ISymbol> getLeftDerivable() {

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/io/NormGrammarReader.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/io/NormGrammarReader.java
@@ -67,6 +67,7 @@ public class NormGrammarReader {
             if(app.getName().equals("Module")) {
                 String modName = moduleName(app);
                 moduleAsts.put(modName, module);
+                grammar.getModulesRead().add(modName);
             }
         }
     }
@@ -122,6 +123,7 @@ public class NormGrammarReader {
             if(app.getName().equals("Module")) {
                 // Module attributes
                 String modName = moduleName(app);
+                grammar.getModulesRead().add(modName);
 
                 // Module has already been processed
                 if(processedModules.contains(modName)) {
@@ -944,8 +946,6 @@ public class NormGrammarReader {
             throw new Exception(
                 "Cannot open module file '" + file.getPath() + "'. Try cleaning the project and rebuilding.");
         }
-
-        grammar.getFilesRead().add(file);
 
         return term;
     }

--- a/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/parsetable/ParseTable.java
+++ b/org.metaborg.sdf2table/src/main/java/org/metaborg/sdf2table/parsetable/ParseTable.java
@@ -143,7 +143,6 @@ public class ParseTable implements IParseTable, Serializable {
         this.productionsMapping.clear();
         this.rightmostContextsMapping.clear();
         this.grammar.cleanupGrammar();
-        System.gc();
     }
 
     private void calculateNullable() {

--- a/sdf3.ext.statix/build.gradle.kts
+++ b/sdf3.ext.statix/build.gradle.kts
@@ -29,6 +29,12 @@ dependencies {
   sourceLanguage(compositeBuild("statix.runtime"))
 }
 
+metaborg { // Do not create Java publication; this project is already published as a Spoofax 2 language.
+  javaCreatePublication = false
+  javaCreateSourcesJar = false
+  javaCreateJavadocJar = false
+}
+
 ecj {
   toolVersion = "3.21.0"
 }

--- a/sdf3.ext.statix/build.gradle.kts
+++ b/sdf3.ext.statix/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.metaborg.core.language.*
+
 plugins {
   id("org.metaborg.gradle.config.java-library")
   id("org.metaborg.devenv.spoofax.gradle.langspec")
@@ -12,6 +14,8 @@ val spoofax2Version: String by ext
 spoofaxLanguageSpecification {
   addSourceDependenciesFromMetaborgYaml.set(false)
   addCompileDependenciesFromMetaborgYaml.set(false)
+  addLanguageContributionsFromMetaborgYaml.set(false)
+  languageContributions.add(LanguageContributionIdentifier(LanguageIdentifier("$group", "org.metaborg.meta.lang.template", LanguageVersion.parse("$version")), "TemplateLang"))
 }
 dependencies {
   compileLanguage(compositeBuild("org.metaborg.meta.lang.esv"))

--- a/sdf3.ext.statix/build.gradle.kts
+++ b/sdf3.ext.statix/build.gradle.kts
@@ -3,7 +3,6 @@ import org.metaborg.core.language.*
 plugins {
   id("org.metaborg.gradle.config.java-library")
   id("org.metaborg.devenv.spoofax.gradle.langspec")
-  id("de.set.ecj") // Use ECJ to speed up compilation of Stratego's generated Java files.
   `maven-publish`
 }
 
@@ -33,11 +32,4 @@ metaborg { // Do not create Java publication; this project is already published 
   javaCreatePublication = false
   javaCreateSourcesJar = false
   javaCreateJavadocJar = false
-}
-
-ecj {
-  toolVersion = "3.21.0"
-}
-tasks.withType<JavaCompile> { // ECJ does not support headerOutputDirectory (-h argument).
-  options.headerOutputDirectory.convention(provider { null })
 }


### PR DESCRIPTION
This PR removes the ECJ build dependency because [the plugin](https://github.com/TwoStone/gradle-eclipse-compiler-plugin) is severely out of date, deprecated, and not supported in recent Gradle versions.